### PR TITLE
Feature/mfconfiguration

### DIFF
--- a/common/default.WeSayConfig
+++ b/common/default.WeSayConfig
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<configuration version="8">
+<configuration version="9">
   <components>
 	<viewTemplate>
 	  <fields>
@@ -9,6 +9,7 @@
 		  <displayName>Word</displayName>
 		  <enabled>True</enabled>
 		  <fieldName>EntryLexicalForm</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>False</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -23,6 +24,7 @@
 		  <displayName>Citation Form</displayName>
 		  <enabled>False</enabled>
 		  <fieldName>citation</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>False</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -37,6 +39,7 @@
 		  <displayName>Definition (Meaning)</displayName>
 		  <enabled>True</enabled>
 		  <fieldName>definition</fieldName>
+		  <meaningField>True</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>True</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -51,6 +54,7 @@
 		  <displayName>Gloss</displayName>
 		  <enabled>False</enabled>
 		  <fieldName>gloss</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>True</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -65,6 +69,7 @@
 		  <displayName>Literal Meaning</displayName>
 		  <enabled>False</enabled>
 		  <fieldName>literal-meaning</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>True</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -79,6 +84,7 @@
 		  <displayName>Note</displayName>
 		  <enabled>True</enabled>
 		  <fieldName>note</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>True</multiParagraph>
 		  <spellCheckingEnabled>True</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -93,6 +99,7 @@
 		  <displayName>Picture</displayName>
 		  <enabled>True</enabled>
 		  <fieldName>Picture</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>False</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -107,6 +114,7 @@
 		  <displayName>PartOfSpeech</displayName>
 		  <enabled>True</enabled>
 		  <fieldName>POS</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>False</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -122,6 +130,7 @@
 		  <displayName>SILCAWL</displayName>
 		  <enabled>False</enabled>
 		  <fieldName>SILCAWL</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>True</multiParagraph>
 		  <spellCheckingEnabled>False</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -136,6 +145,7 @@
 		  <displayName>Example Sentence</displayName>
 		  <enabled>True</enabled>
 		  <fieldName>ExampleSentence</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>True</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -150,6 +160,7 @@
 		  <displayName>Example Translation</displayName>
 		  <enabled>False</enabled>
 		  <fieldName>ExampleTranslation</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>True</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -164,6 +175,7 @@
 		  <displayName>Sem Dom</displayName>
 		  <enabled>True</enabled>
 		  <fieldName>semantic-domain-ddp4</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>False</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -179,6 +191,7 @@
 		  <displayName>Base Form</displayName>
 		  <enabled>False</enabled>
 		  <fieldName>BaseForm</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>False</spellCheckingEnabled>
 		  <multiplicity>ZeroOr1</multiplicity>
@@ -193,6 +206,7 @@
 		  <displayName>Cross Reference</displayName>
 		  <enabled>False</enabled>
 		  <fieldName>confer</fieldName>
+		  <meaningField>False</meaningField>
 		  <multiParagraph>False</multiParagraph>
 		  <spellCheckingEnabled>False</spellCheckingEnabled>
 		  <multiplicity>ZeroOrMore</multiplicity>
@@ -207,7 +221,9 @@
   </components>
   <tasks>
 	<task taskName="Dashboard" visible="true" />
-	<task taskName="Dictionary" visible="true" />
+	<task taskName="Dictionary" visible="true">
+	  <meaningField>definition</meaningField>
+	</task>
 	<task taskName="AddMissingInfo" visible="false">
 	  <label>Meanings</label>
 	  <longLabel>Add Meanings</longLabel>

--- a/src/Addin.Backup.Tests/Addin.Backup.Tests.csproj
+++ b/src/Addin.Backup.Tests/Addin.Backup.Tests.csproj
@@ -138,6 +138,9 @@
       <Name>WeSay.TestUtilities</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	   Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Addin.Transform.Tests/Addin.Transform.Tests.csproj
+++ b/src/Addin.Transform.Tests/Addin.Transform.Tests.csproj
@@ -162,4 +162,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
 </Project>

--- a/src/LexicalModel.Tests/LexicalModel.Tests.csproj
+++ b/src/LexicalModel.Tests/LexicalModel.Tests.csproj
@@ -171,6 +171,9 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	   Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/LexicalModel/Field.cs
+++ b/src/LexicalModel/Field.cs
@@ -23,6 +23,7 @@ namespace WeSay.LexicalModel
 		private string _dataTypeName;
 		private bool _enabled;
 		private bool _isSpellCheckingEnabled;
+		private bool _isMeaningField;
 		//private string _configurationName;
 
 		private bool _enabledNotSet = true;
@@ -549,6 +550,14 @@ namespace WeSay.LexicalModel
 			get { return "newField"; }
 		}
 
+		[Description("This setting is changed in the Dictionary Browse and Edit configuration.")]
+		[ReflectorProperty("meaningField", Required = false)]
+		public bool IsMeaningField
+		{
+			get { return _isMeaningField; }
+			set { _isMeaningField = value; }
+		}
+
 		public bool CanOmitFromMainViewTemplate
 		{
 			get
@@ -558,16 +567,10 @@ namespace WeSay.LexicalModel
 					return false;
 				}
 
-#if GlossMeaning
-				if(_fieldName == FieldNames.SenseGloss.ToString())
-					return false;
-#else
-				if (_fieldName == LexSense.WellKnownProperties.Definition)
+				if (IsMeaningField)
 				{
 					return false;
 				}
-#endif
-
 				return true;
 			}
 		}

--- a/src/LexicalTools.Tests/DictionaryControlTests.cs
+++ b/src/LexicalTools.Tests/DictionaryControlTests.cs
@@ -154,7 +154,7 @@ namespace WeSay.LexicalTools.Tests
 
 			DictionaryControl.Factory dictControlFactory = (memory => new DictionaryControl(_entryViewFactory, _lexEntryRepository, viewTemplate, memory, new StringLogger()));
 
-			_task = new DictionaryTask(dictControlFactory, DictionaryBrowseAndEditConfiguration.CreateForTests(), _lexEntryRepository,  new TaskMemoryRepository());//, new UserSettingsForTask());
+			_task = new DictionaryTask(dictControlFactory, DictionaryBrowseAndEditConfiguration.CreateForTests("definition"), _lexEntryRepository,  new TaskMemoryRepository());//, new UserSettingsForTask());
 			_detailTaskPage = new TabPage();
 			ActivateTask();
 

--- a/src/LexicalTools.Tests/DictionaryTaskTests.cs
+++ b/src/LexicalTools.Tests/DictionaryTaskTests.cs
@@ -61,7 +61,7 @@ namespace WeSay.LexicalTools.Tests
 			_dictControlFactory = (memory=>new DictionaryControl(entryViewFactory, _lexEntryRepository,_viewTemplate, memory, new StringLogger()));
 
 			_taskMemoryRepository = new TaskMemoryRepository();
-			_task = new DictionaryTask(_dictControlFactory,  DictionaryBrowseAndEditConfiguration.CreateForTests(),  _lexEntryRepository,
+			_task = new DictionaryTask(_dictControlFactory,  DictionaryBrowseAndEditConfiguration.CreateForTests("definition"),  _lexEntryRepository,
 				_taskMemoryRepository);
 
 //            _task = new DictionaryTask( DictionaryBrowseAndEditConfiguration.CreateForTests(),  _lexEntryRepository,
@@ -86,7 +86,7 @@ namespace WeSay.LexicalTools.Tests
 		[Test]
 		public void CreateAndActivate_TaskMemoryIsEmpty_Ok()
 		{
-			var task = new DictionaryTask(_dictControlFactory,  DictionaryBrowseAndEditConfiguration.CreateForTests(), _lexEntryRepository,
+			var task = new DictionaryTask(_dictControlFactory,  DictionaryBrowseAndEditConfiguration.CreateForTests("definition"), _lexEntryRepository,
 				new TaskMemoryRepository());
 			task.Activate();
 			task.Deactivate();
@@ -105,7 +105,7 @@ namespace WeSay.LexicalTools.Tests
 		[Test]
 		public void CreateAndActivate_LastUrlDoesntExistAnymore_DoesNotCrash()
 		{
-			DictionaryBrowseAndEditConfiguration config = DictionaryBrowseAndEditConfiguration.CreateForTests();
+			DictionaryBrowseAndEditConfiguration config = DictionaryBrowseAndEditConfiguration.CreateForTests("definition");
 
 			_taskMemoryRepository.FindOrCreateSettingsByTaskId(config.TaskName).Set(DictionaryTask.LastUrlKey, "longGone");
 

--- a/src/LexicalTools.Tests/LexicalTools.Tests.csproj
+++ b/src/LexicalTools.Tests/LexicalTools.Tests.csproj
@@ -178,6 +178,9 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	   Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/LexicalTools/AddMissingInfo/MissingInfoConfiguration.cs
+++ b/src/LexicalTools/AddMissingInfo/MissingInfoConfiguration.cs
@@ -218,8 +218,7 @@ namespace WeSay.LexicalTools.AddMissingInfo
 		{
 			get
 			{
-				string s = string.Empty;
-				_fieldsReadOnly.ForEach(f => s += ", " + f);
+				string s = string.Join(", ", _fieldsReadOnly);
 				return s.TrimStart(new char[] { ' ', ',' });
 			}
 		}
@@ -228,8 +227,7 @@ namespace WeSay.LexicalTools.AddMissingInfo
 		{
 			get
 			{
-				string s = string.Empty;
-				_fieldsToShow.ForEach(f=>s+=", "+f);
+				string s = string.Join(", ", _fieldsToShow);
 				return s.TrimStart(new char[] {' ', ','});
 			}
 		}

--- a/src/LexicalTools/AddMissingInfo/MissingInfoConfiguration.cs
+++ b/src/LexicalTools/AddMissingInfo/MissingInfoConfiguration.cs
@@ -298,5 +298,10 @@ namespace WeSay.LexicalTools.AddMissingInfo
 		{
 			return _fieldsToShow.Contains(fieldName);
 		}
+
+		public bool IncludesReadOnlyField(string fieldName)
+		{
+			return _fieldsReadOnly.Contains(fieldName);
+		}
 	}
 }

--- a/src/LexicalTools/AddMissingInfo/MissingInfoConfiguration.cs
+++ b/src/LexicalTools/AddMissingInfo/MissingInfoConfiguration.cs
@@ -218,8 +218,7 @@ namespace WeSay.LexicalTools.AddMissingInfo
 		{
 			get
 			{
-				string s = string.Join(", ", _fieldsReadOnly);
-				return s.TrimStart(new char[] { ' ', ',' });
+				return string.Join(", ", _fieldsReadOnly);
 			}
 		}
 
@@ -227,8 +226,7 @@ namespace WeSay.LexicalTools.AddMissingInfo
 		{
 			get
 			{
-				string s = string.Join(", ", _fieldsToShow);
-				return s.TrimStart(new char[] {' ', ','});
+				return string.Join(", ", _fieldsToShow);
 			}
 		}
 

--- a/src/LexicalTools/AddMissingInfo/MissingInfoConfiguration.cs
+++ b/src/LexicalTools/AddMissingInfo/MissingInfoConfiguration.cs
@@ -10,16 +10,20 @@ using Palaso.DictionaryServices.Model;
 
 namespace WeSay.LexicalTools.AddMissingInfo
 {
-	public class MissingInfoConfiguration : TaskConfigurationBase, ITaskConfiguration, ICareThatWritingSystemIdChanged
+	public class MissingInfoConfiguration : TaskConfigurationBase, ITaskConfiguration, ICareThatWritingSystemIdChanged, ICareThatMeaningFieldChanged
 	{
 		private List<string> _fieldsToShow;
+		private List<string> _fieldsReadOnly;
+		private string _field;
 		private List<string> _writingSystemsWeWantToFillIn;
 		private List<string> _writingSystemsWhichAreRequired;
 
 		public MissingInfoConfiguration(string configurationXml)//, ViewTemplate viewTemplate)
 			: base(configurationXml)
 		{
+			_field = GetStringFromConfigNode("field");
 			_fieldsToShow = GetStringFromConfigNode("showFields").SplitTrimmed(',');
+			_fieldsReadOnly = GetStringFromConfigNode("readOnly", "").SplitTrimmed(',');
 			_writingSystemsWeWantToFillIn = GetStringFromConfigNode("writingSystemsToMatch", string.Empty).SplitTrimmed(',');
 			_writingSystemsWhichAreRequired = GetStringFromConfigNode("writingSystemsWhichAreRequired", string.Empty).SplitTrimmed(',');
 		}
@@ -31,6 +35,7 @@ namespace WeSay.LexicalTools.AddMissingInfo
 
 		public event EventHandler WritingSystemIdChanged;
 		public event EventHandler WritingSystemIdDeleted;
+		//public event EventHandler ChangeMeaningField;
 
 		public void OnWritingSystemIdChanged(string from, string to)
 		{
@@ -85,6 +90,29 @@ namespace WeSay.LexicalTools.AddMissingInfo
 			}
 		}
 
+		public void OnMeaningFieldChanged(string from, string to)
+		{
+			// if field contains the old meaning field then change it
+			if (_field.Equals(from))
+				_field = to;
+
+			// if showfields contains the old meaning field then change it
+			if (IncludesField(from))
+			{
+				SetInclusionOfField(from, false);
+				SetInclusionOfField(to, true);
+			}
+
+			// if read-only contains the old meaning field then change it
+			if (_fieldsReadOnly.Contains(from))
+			{
+				if (!_fieldsReadOnly.Contains(to))
+					_fieldsReadOnly.Add(to);
+				if (_fieldsReadOnly.Contains(from))
+					_fieldsReadOnly.Remove(from);
+			}
+		}
+
 		public DashboardGroup Group
 		{
 			get
@@ -111,7 +139,7 @@ namespace WeSay.LexicalTools.AddMissingInfo
 				yield return new KeyValuePair<string, string>("description", Description);
 				yield return new KeyValuePair<string, string>("field", MissingInfoFieldName);
 				yield return new KeyValuePair<string, string>("showFields", FieldsToShowCommaSeparated);
-				yield return new KeyValuePair<string, string>("readOnly", FieldsToShowReadOnly);
+				yield return new KeyValuePair<string, string>("readOnly", FieldsToShowReadOnlyCommaSeparated);
 				yield return new KeyValuePair<string, string>("writingSystemsToMatch", WritingSystemsWeWantToFillInCommaSeparated);
 				yield return new KeyValuePair<string, string>("writingSystemsWhichAreRequired", WritingSystemsWhichAreRequiredCommaSeparated);
 			}
@@ -186,9 +214,14 @@ namespace WeSay.LexicalTools.AddMissingInfo
 			return true;
 		}
 
-		public string FieldsToShowReadOnly
+		public string FieldsToShowReadOnlyCommaSeparated
 		{
-			get { return GetStringFromConfigNode("readOnly", string.Empty); ; }
+			get
+			{
+				string s = string.Empty;
+				_fieldsReadOnly.ForEach(f => s += ", " + f);
+				return s.TrimStart(new char[] { ' ', ',' });
+			}
 		}
 
 		public string FieldsToShowCommaSeparated //<showFields>
@@ -217,7 +250,7 @@ namespace WeSay.LexicalTools.AddMissingInfo
 
 		public string MissingInfoFieldName //<field>
 		{
-			get { return GetStringFromConfigNode("field"); }
+			get { return _field; }
 		}
 
 		public string[] WritingSystemsWeWantToFillInArray

--- a/src/LexicalTools/AddMissingInfo/MissingInfoViewMaker.cs
+++ b/src/LexicalTools/AddMissingInfo/MissingInfoViewMaker.cs
@@ -12,13 +12,13 @@ namespace WeSay.LexicalTools.AddMissingInfo
 	{
 		public static ViewTemplate CreateViewTemplate(MissingInfoConfiguration config, ViewTemplate baseTemplate)
 		{
-			var template = CreateViewTemplateFromListOfFields(baseTemplate, config.FieldsToShowCommaSeparated, config.FieldsToShowReadOnly);
+			var template = CreateViewTemplateFromListOfFields(baseTemplate, config.FieldsToShowCommaSeparated, config.FieldsToShowReadOnlyCommaSeparated);
 
 			//see WS-1120 (martin_diprose@sil.org) Add option to limit "add meanings" task to the ones that have a semantic domain
 			//for now, let's just turn off all ghosts in these fill-in tasks
 			template.DoWantGhosts = false;
 
-			MarkReadOnlyFields(template, config.FieldsToShowReadOnly);
+			MarkReadOnlyFields(template, config.FieldsToShowReadOnlyCommaSeparated);
 
 			//hack until we overhaul how Tasks are setup:
 			var isBaseFormFillingTask = config.FieldsToShowCommaSeparated.Contains(LexEntry.WellKnownProperties.BaseForm);

--- a/src/LexicalTools/DictionaryBrowseAndEdit/DictionaryBrowseAndEditConfiguration.cs
+++ b/src/LexicalTools/DictionaryBrowseAndEdit/DictionaryBrowseAndEditConfiguration.cs
@@ -5,7 +5,7 @@ using WeSay.Project;
 
 namespace WeSay.LexicalTools.DictionaryBrowseAndEdit
 {
-	public class DictionaryBrowseAndEditConfiguration : TaskConfigurationBase, ITaskConfiguration
+	public class DictionaryBrowseAndEditConfiguration : TaskConfigurationBase, ITaskConfiguration, ICareThatMeaningFieldChanged
 	{
 		public string MeaningField { get; set; }
 
@@ -42,14 +42,6 @@ namespace WeSay.LexicalTools.DictionaryBrowseAndEdit
 			return "Dictionary Browse & Edit";
 		}
 
-		public string meaningField
-		{
-			get
-			{
-				return GetStringFromConfigNode("meaningField", "definition");
-			}
-		}
-
 		public string LongLabel
 		{
 			get
@@ -81,14 +73,12 @@ namespace WeSay.LexicalTools.DictionaryBrowseAndEdit
 			get { return true; }
 		}
 
-		public bool ChangeToDefinition()
+		public void OnMeaningFieldChanged(string from, string to)
 		{
-			return true;
-		}
-
-		public bool ChangeToGloss()
-		{
-			return true;
+			if (!MeaningField.Equals(from))
+			{
+				MeaningField = from;
+			}
 		}
 
 		public static DictionaryBrowseAndEditConfiguration CreateForTests(string meaningField)

--- a/src/LexicalTools/DictionaryBrowseAndEdit/DictionaryBrowseAndEditConfiguration.cs
+++ b/src/LexicalTools/DictionaryBrowseAndEdit/DictionaryBrowseAndEditConfiguration.cs
@@ -7,16 +7,19 @@ namespace WeSay.LexicalTools.DictionaryBrowseAndEdit
 {
 	public class DictionaryBrowseAndEditConfiguration : TaskConfigurationBase, ITaskConfiguration
 	{
+		public string MeaningField { get; set; }
+
 		public DictionaryBrowseAndEditConfiguration(string xml)
 			:base(xml)
 		{
+			MeaningField = GetStringFromConfigNode("meaningField", "definition");
 		}
 
 		protected override IEnumerable<KeyValuePair<string, string>> ValuesToSave
 		{
 			get
 			{
-				yield break;
+				yield return new KeyValuePair<string, string>("meaningField", MeaningField);
 			}
 		}
 
@@ -37,6 +40,14 @@ namespace WeSay.LexicalTools.DictionaryBrowseAndEdit
 		public override string ToString()
 		{
 			return "Dictionary Browse & Edit";
+		}
+
+		public string meaningField
+		{
+			get
+			{
+				return GetStringFromConfigNode("meaningField", "definition");
+			}
 		}
 
 		public string LongLabel
@@ -70,12 +81,23 @@ namespace WeSay.LexicalTools.DictionaryBrowseAndEdit
 			get { return true; }
 		}
 
+		public bool ChangeToDefinition()
+		{
+			return true;
+		}
 
-		public static DictionaryBrowseAndEditConfiguration CreateForTests()
+		public bool ChangeToGloss()
+		{
+			return true;
+		}
+
+		public static DictionaryBrowseAndEditConfiguration CreateForTests(string meaningField)
 		{
 			string x =
 			   String.Format(
-				   @"   <task taskName='Dictionary' visible='true'>  </task>");
+				   @"   <task taskName='Dictionary' visible='true'>
+	  <meaningField>{0}</meaningField>
+	</task>", meaningField);
 			return new DictionaryBrowseAndEditConfiguration(x);
 		}
 	}

--- a/src/LexicalTools/DictionaryBrowseAndEdit/DictionaryBrowseAndEditConfiguration.cs
+++ b/src/LexicalTools/DictionaryBrowseAndEdit/DictionaryBrowseAndEditConfiguration.cs
@@ -75,9 +75,9 @@ namespace WeSay.LexicalTools.DictionaryBrowseAndEdit
 
 		public void OnMeaningFieldChanged(string from, string to)
 		{
-			if (!MeaningField.Equals(from))
+			if (!MeaningField.Equals(to))
 			{
-				MeaningField = from;
+				MeaningField = to;
 			}
 		}
 

--- a/src/WeSay.App.Tests/WeSay.App.Tests.csproj
+++ b/src/WeSay.App.Tests/WeSay.App.Tests.csproj
@@ -157,4 +157,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
 </Project>

--- a/src/WeSay.ConfigTool.Tests/WeSay.ConfigTool.Tests.csproj
+++ b/src/WeSay.ConfigTool.Tests/WeSay.ConfigTool.Tests.csproj
@@ -160,6 +160,9 @@
     <None Include="App.config" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	   Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/WeSay.ConfigTool/FieldDetailControl.Designer.cs
+++ b/src/WeSay.ConfigTool/FieldDetailControl.Designer.cs
@@ -49,14 +49,15 @@ namespace WeSay.ConfigTool
 			this._descriptionLabel = new System.Windows.Forms.Label();
 			this._writingSystemsControlLabel = new System.Windows.Forms.Label();
 			this._multiParagraphLabel = new System.Windows.Forms.Label();
-			this._writingSystemsControl = new WeSay.ConfigTool.WritingSystemForFieldControl();
 			this._multiParagraph = new System.Windows.Forms.CheckBox();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+			this.possibleMeaningField = new System.Windows.Forms.Label();
+			this._writingSystemsControl = new WeSay.ConfigTool.WritingSystemForFieldControl();
 			this.tableLayoutPanel1.SuspendLayout();
 			this.SuspendLayout();
-			//
+			// 
 			// tableLayoutPanel1
-			//
+			// 
 			this.tableLayoutPanel1.ColumnCount = 2;
 			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 45F));
 			this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 55F));
@@ -81,9 +82,10 @@ namespace WeSay.ConfigTool
 			this.tableLayoutPanel1.Controls.Add(this._multiParagraphLabel, 0, 9);
 			this.tableLayoutPanel1.Controls.Add(this._writingSystemsControl, 1, 10);
 			this.tableLayoutPanel1.Controls.Add(this._multiParagraph, 1, 9);
+			this.tableLayoutPanel1.Controls.Add(this.possibleMeaningField, 0, 13);
 			this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 17);
 			this.tableLayoutPanel1.Name = "tableLayoutPanel1";
-			this.tableLayoutPanel1.RowCount = 12;
+			this.tableLayoutPanel1.RowCount = 13;
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
@@ -96,23 +98,26 @@ namespace WeSay.ConfigTool
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
 			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle());
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+			this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
 			this.tableLayoutPanel1.Size = new System.Drawing.Size(300, 513);
 			this.tableLayoutPanel1.TabIndex = 0;
-			//
+			// 
 			// _fieldName
-			//
-			this._fieldName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-			| System.Windows.Forms.AnchorStyles.Right)));
-			this._fieldName.Location = new System.Drawing.Point(119, 29);
+			// 
+			this._fieldName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this._fieldName.Location = new System.Drawing.Point(138, 29);
 			this._fieldName.Name = "_fieldName";
-			this._fieldName.Size = new System.Drawing.Size(178, 20);
+			this._fieldName.Size = new System.Drawing.Size(159, 20);
 			this._fieldName.TabIndex = 1;
 			this.toolTip1.SetToolTip(this._fieldName, "This corresponds to the FLEx \"Custom Field Name\", and is the name that will be us" +
-		"ed in the LIFT xml file. ");
+        "ed in the LIFT xml file. ");
 			this._fieldName.TextChanged += new System.EventHandler(this._fieldName_TextChanged);
-			//
+			// 
 			// _displayLabel
-			//
+			// 
 			this._displayLabel.AutoSize = true;
 			this._displayLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this._displayLabel.Location = new System.Drawing.Point(3, 0);
@@ -121,9 +126,9 @@ namespace WeSay.ConfigTool
 			this._displayLabel.TabIndex = 0;
 			this._displayLabel.Text = "Name for display";
 			this.toolTip1.SetToolTip(this._displayLabel, "Name as the user will see it");
-			//
+			// 
 			// _fieldNameLabel
-			//
+			// 
 			this._fieldNameLabel.AutoSize = true;
 			this._fieldNameLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this._fieldNameLabel.Location = new System.Drawing.Point(3, 26);
@@ -132,21 +137,21 @@ namespace WeSay.ConfigTool
 			this._fieldNameLabel.TabIndex = 1;
 			this._fieldNameLabel.Text = "Name in file";
 			this.toolTip1.SetToolTip(this._fieldNameLabel, "Name as it will be stored in the xml file");
-			//
+			// 
 			// _displayName
-			//
-			this._displayName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-			| System.Windows.Forms.AnchorStyles.Right)));
-			this._displayName.Location = new System.Drawing.Point(119, 3);
+			// 
+			this._displayName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this._displayName.Location = new System.Drawing.Point(138, 3);
 			this._displayName.Name = "_displayName";
-			this._displayName.Size = new System.Drawing.Size(178, 20);
+			this._displayName.Size = new System.Drawing.Size(159, 20);
 			this._displayName.TabIndex = 0;
 			this.toolTip1.SetToolTip(this._displayName, "The name the user will see.");
 			this._displayName.TextChanged += new System.EventHandler(this.OnDisplayName_TextChanged);
 			this._displayName.Leave += new System.EventHandler(this.OnLeaveDisplayName);
-			//
+			// 
 			// _classLabel
-			//
+			// 
 			this._classLabel.AutoSize = true;
 			this._classLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this._classLabel.Location = new System.Drawing.Point(3, 52);
@@ -155,9 +160,9 @@ namespace WeSay.ConfigTool
 			this._classLabel.TabIndex = 4;
 			this._classLabel.Text = "Belongs to";
 			this.toolTip1.SetToolTip(this._classLabel, "The part of the entry that this field is a part of.");
-			//
+			// 
 			// _dataTypeLabel
-			//
+			// 
 			this._dataTypeLabel.AutoSize = true;
 			this._dataTypeLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this._dataTypeLabel.Location = new System.Drawing.Point(3, 79);
@@ -166,46 +171,46 @@ namespace WeSay.ConfigTool
 			this._dataTypeLabel.TabIndex = 5;
 			this._dataTypeLabel.Text = "Data Type";
 			this.toolTip1.SetToolTip(this._dataTypeLabel, "The kind of data goes in this field.");
-			//
+			// 
 			// _classNameCombo
-			//
-			this._classNameCombo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-			| System.Windows.Forms.AnchorStyles.Right)));
+			// 
+			this._classNameCombo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
 			this._classNameCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this._classNameCombo.FormattingEnabled = true;
-			this._classNameCombo.Location = new System.Drawing.Point(119, 55);
+			this._classNameCombo.Location = new System.Drawing.Point(138, 55);
 			this._classNameCombo.Name = "_classNameCombo";
-			this._classNameCombo.Size = new System.Drawing.Size(178, 21);
+			this._classNameCombo.Size = new System.Drawing.Size(159, 21);
 			this._classNameCombo.TabIndex = 2;
 			this._classNameCombo.SelectedIndexChanged += new System.EventHandler(this._classNameCombo_SelectedIndexChanged);
-			//
+			// 
 			// _dataTypeCombo
-			//
-			this._dataTypeCombo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-			| System.Windows.Forms.AnchorStyles.Right)));
+			// 
+			this._dataTypeCombo.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
 			this._dataTypeCombo.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this._dataTypeCombo.FormattingEnabled = true;
-			this._dataTypeCombo.Location = new System.Drawing.Point(119, 82);
+			this._dataTypeCombo.Location = new System.Drawing.Point(138, 82);
 			this._dataTypeCombo.Name = "_dataTypeCombo";
-			this._dataTypeCombo.Size = new System.Drawing.Size(178, 21);
+			this._dataTypeCombo.Size = new System.Drawing.Size(159, 21);
 			this._dataTypeCombo.TabIndex = 3;
 			this._dataTypeCombo.SelectedIndexChanged += new System.EventHandler(this.OnDataTypeCombo_SelectedIndexChanged);
-			//
+			// 
 			// _optionsFileName
-			//
-			this._optionsFileName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-			| System.Windows.Forms.AnchorStyles.Right)));
+			// 
+			this._optionsFileName.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
 			this._optionsFileName.Enabled = false;
-			this._optionsFileName.Location = new System.Drawing.Point(119, 109);
+			this._optionsFileName.Location = new System.Drawing.Point(138, 109);
 			this._optionsFileName.Name = "_optionsFileName";
-			this._optionsFileName.Size = new System.Drawing.Size(178, 20);
+			this._optionsFileName.Size = new System.Drawing.Size(159, 20);
 			this._optionsFileName.TabIndex = 4;
 			this._optionsFileName.TextChanged += new System.EventHandler(this._optionsFileName_TextChanged);
-			//
+			// 
 			// _normallyHidden
-			//
+			// 
 			this._normallyHidden.AutoSize = true;
-			this._normallyHidden.Location = new System.Drawing.Point(119, 187);
+			this._normallyHidden.Location = new System.Drawing.Point(138, 187);
 			this._normallyHidden.Name = "_normallyHidden";
 			this._normallyHidden.Size = new System.Drawing.Size(140, 17);
 			this._normallyHidden.TabIndex = 7;
@@ -213,9 +218,9 @@ namespace WeSay.ConfigTool
 			this.toolTip1.SetToolTip(this._normallyHidden, ".");
 			this._normallyHidden.UseVisualStyleBackColor = true;
 			this._normallyHidden.CheckedChanged += new System.EventHandler(this._normallyHidden_CheckedChanged);
-			//
+			// 
 			// _normallyHiddenLabel
-			//
+			// 
 			this._normallyHiddenLabel.AutoSize = true;
 			this._normallyHiddenLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this._normallyHiddenLabel.Location = new System.Drawing.Point(3, 184);
@@ -224,9 +229,9 @@ namespace WeSay.ConfigTool
 			this._normallyHiddenLabel.TabIndex = 10;
 			this._normallyHiddenLabel.Text = "Visibility";
 			this.toolTip1.SetToolTip(this._normallyHiddenLabel, "Tick this box for fields which are  not used in most records");
-			//
+			// 
 			// _enableSpellingLabel
-			//
+			// 
 			this._enableSpellingLabel.AutoSize = true;
 			this._enableSpellingLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this._enableSpellingLabel.Location = new System.Drawing.Point(3, 132);
@@ -234,11 +239,11 @@ namespace WeSay.ConfigTool
 			this._enableSpellingLabel.Size = new System.Drawing.Size(57, 16);
 			this._enableSpellingLabel.TabIndex = 11;
 			this._enableSpellingLabel.Text = "Spelling";
-			this.toolTip1.SetToolTip(this._enableSpellingLabel, "Tick this box to enable spell checking for input systems with installed spell c" +
-		"hecker support");
-			//
+			this.toolTip1.SetToolTip(this._enableSpellingLabel, "Tick this box to enable spell checking for input systems with installed spell che" +
+        "cker support");
+			// 
 			// _optionListFileLabel
-			//
+			// 
 			this._optionListFileLabel.AutoSize = true;
 			this._optionListFileLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this._optionListFileLabel.Location = new System.Drawing.Point(3, 106);
@@ -247,20 +252,20 @@ namespace WeSay.ConfigTool
 			this._optionListFileLabel.TabIndex = 8;
 			this._optionListFileLabel.Text = "Option List File";
 			this.toolTip1.SetToolTip(this._optionListFileLabel, "Options are stored in a xml file under this name.");
-			//
+			// 
 			// _enableSpelling
-			//
+			// 
 			this._enableSpelling.AutoSize = true;
-			this._enableSpelling.Location = new System.Drawing.Point(119, 135);
+			this._enableSpelling.Location = new System.Drawing.Point(138, 135);
 			this._enableSpelling.Name = "_enableSpelling";
 			this._enableSpelling.Size = new System.Drawing.Size(130, 17);
 			this._enableSpelling.TabIndex = 12;
 			this._enableSpelling.Text = "Enable spell checking";
 			this._enableSpelling.UseVisualStyleBackColor = true;
 			this._enableSpelling.CheckedChanged += new System.EventHandler(this._enableSpelling_CheckedChanged);
-			//
+			// 
 			// spellingNotEnabledWarning
-			//
+			// 
 			this.spellingNotEnabledWarning.AutoSize = true;
 			this.tableLayoutPanel1.SetColumnSpan(this.spellingNotEnabledWarning, 2);
 			this.spellingNotEnabledWarning.ForeColor = System.Drawing.Color.Crimson;
@@ -270,22 +275,22 @@ namespace WeSay.ConfigTool
 			this.spellingNotEnabledWarning.Size = new System.Drawing.Size(263, 26);
 			this.spellingNotEnabledWarning.TabIndex = 13;
 			this.spellingNotEnabledWarning.Text = "Spellchecking has not been installed on this machine. Please install Enchant to e" +
-	"nable this feature.";
-			//
+    "nable this feature.";
+			// 
 			// _description
-			//
-			this._description.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-			| System.Windows.Forms.AnchorStyles.Right)));
+			// 
+			this._description.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
 			this._description.Enabled = false;
-			this._description.Location = new System.Drawing.Point(119, 339);
+			this._description.Location = new System.Drawing.Point(138, 339);
 			this._description.Multiline = true;
 			this._description.Name = "_description";
-			this._description.Size = new System.Drawing.Size(178, 99);
+			this._description.Size = new System.Drawing.Size(159, 99);
 			this._description.TabIndex = 5;
 			this._description.TextChanged += new System.EventHandler(this._description_TextChanged);
-			//
+			// 
 			// _descriptionLabel
-			//
+			// 
 			this._descriptionLabel.AutoSize = true;
 			this._descriptionLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this._descriptionLabel.Location = new System.Drawing.Point(3, 336);
@@ -294,9 +299,9 @@ namespace WeSay.ConfigTool
 			this._descriptionLabel.TabIndex = 9;
 			this._descriptionLabel.Text = "Description";
 			this.toolTip1.SetToolTip(this._descriptionLabel, "Information about the use of this field.");
-			//
+			// 
 			// _writingSystemsControlLabel
-			//
+			// 
 			this._writingSystemsControlLabel.AutoSize = true;
 			this._writingSystemsControlLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this._writingSystemsControlLabel.Location = new System.Drawing.Point(3, 230);
@@ -305,9 +310,9 @@ namespace WeSay.ConfigTool
 			this._writingSystemsControlLabel.TabIndex = 10;
 			this._writingSystemsControlLabel.Text = "Input Systems";
 			this.toolTip1.SetToolTip(this._writingSystemsControlLabel, "Mark which input systems to use for this field.");
-			//
+			// 
 			// _multiParagraphLabel
-			//
+			// 
 			this._multiParagraphLabel.AutoSize = true;
 			this._multiParagraphLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this._multiParagraphLabel.Location = new System.Drawing.Point(3, 207);
@@ -315,29 +320,42 @@ namespace WeSay.ConfigTool
 			this._multiParagraphLabel.Size = new System.Drawing.Size(72, 16);
 			this._multiParagraphLabel.TabIndex = 9;
 			this._multiParagraphLabel.Text = "Paragraph";
-			//
-			// _writingSystemsControl
-			//
-			this._writingSystemsControl.CurrentField = null;
-			this._writingSystemsControl.Dock = System.Windows.Forms.DockStyle.Fill;
-			this._writingSystemsControl.Location = new System.Drawing.Point(119, 233);
-			this._writingSystemsControl.Name = "_writingSystemsControl";
-			this._writingSystemsControl.Size = new System.Drawing.Size(178, 100);
-			this._writingSystemsControl.TabIndex = 6;
-			//
+			// 
 			// _multiParagraph
-			//
+			// 
 			this._multiParagraph.AutoSize = true;
-			this._multiParagraph.Location = new System.Drawing.Point(119, 210);
+			this._multiParagraph.Location = new System.Drawing.Point(138, 210);
 			this._multiParagraph.Name = "_multiParagraph";
 			this._multiParagraph.Size = new System.Drawing.Size(145, 17);
 			this._multiParagraph.TabIndex = 7;
 			this._multiParagraph.Text = "Allow multiple paragraphs";
 			this._multiParagraph.UseVisualStyleBackColor = true;
 			this._multiParagraph.CheckedChanged += new System.EventHandler(this._multiParagraph_CheckedChanged);
-			//
+			// 
+			// possibleMeaningField
+			// 
+			this.possibleMeaningField.AutoSize = true;
+			this.tableLayoutPanel1.SetColumnSpan(this.possibleMeaningField, 2);
+			this.possibleMeaningField.Location = new System.Drawing.Point(3, 441);
+			this.possibleMeaningField.Name = "possibleMeaningField";
+			this.possibleMeaningField.Padding = new System.Windows.Forms.Padding(0, 16, 0, 0);
+			this.possibleMeaningField.Size = new System.Drawing.Size(284, 42);
+			this.possibleMeaningField.TabIndex = 14;
+			this.possibleMeaningField.Text = "This field may be chosen as the meaning field on the Task configuration for Dicti" +
+    "onary Browse and Edit.";
+			this.possibleMeaningField.Visible = false;
+			// 
+			// _writingSystemsControl
+			// 
+			this._writingSystemsControl.CurrentField = null;
+			this._writingSystemsControl.Dock = System.Windows.Forms.DockStyle.Fill;
+			this._writingSystemsControl.Location = new System.Drawing.Point(138, 233);
+			this._writingSystemsControl.Name = "_writingSystemsControl";
+			this._writingSystemsControl.Size = new System.Drawing.Size(159, 100);
+			this._writingSystemsControl.TabIndex = 6;
+			// 
 			// FieldDetailControl
-			//
+			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
 			this.Controls.Add(this.tableLayoutPanel1);
@@ -374,5 +392,6 @@ namespace WeSay.ConfigTool
 		private System.Windows.Forms.Label spellingNotEnabledWarning;
 		private System.Windows.Forms.Label _multiParagraphLabel;
 		private System.Windows.Forms.CheckBox _multiParagraph;
+		private System.Windows.Forms.Label possibleMeaningField;
 	}
 }

--- a/src/WeSay.ConfigTool/FieldDetailControl.cs
+++ b/src/WeSay.ConfigTool/FieldDetailControl.cs
@@ -80,6 +80,14 @@ namespace WeSay.ConfigTool
 				FillClassNameCombo();
 				FillDataTypeCombo();
 				_writingSystemsControl.CurrentField = value;
+				if (_field.FieldName.Equals("definition") || _field.FieldName.Equals("gloss"))
+				{
+					possibleMeaningField.Visible = true;
+				}
+				else
+				{
+					possibleMeaningField.Visible = false;
+				}
 				UpdateDisplay();
 				_displayName.SelectAll();
 				_displayName.Focus();

--- a/src/WeSay.ConfigTool/FieldDetailControl.cs
+++ b/src/WeSay.ConfigTool/FieldDetailControl.cs
@@ -80,14 +80,9 @@ namespace WeSay.ConfigTool
 				FillClassNameCombo();
 				FillDataTypeCombo();
 				_writingSystemsControl.CurrentField = value;
-				if (_field.FieldName.Equals("definition") || _field.FieldName.Equals("gloss"))
-				{
-					possibleMeaningField.Visible = true;
-				}
-				else
-				{
-					possibleMeaningField.Visible = false;
-				}
+
+				possibleMeaningField.Visible = (_field.FieldName == "definition" || _field.FieldName == "gloss") ? true : false;
+
 				UpdateDisplay();
 				_displayName.SelectAll();
 				_displayName.Focus();

--- a/src/WeSay.ConfigTool/FieldDetailControl.resx
+++ b/src/WeSay.ConfigTool/FieldDetailControl.resx
@@ -1,123 +1,123 @@
 <?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!--
-	Microsoft ResX Schema
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
 
-	Version 2.0
-
-	The primary goals of this format is to allow a simple XML format
-	that is mostly human readable. The generation and parsing of the
-	various data types are done through the TypeConverter classes
-	associated with the data types.
-
-	Example:
-
-	... ado.net/XML headers & schema ...
-	<resheader name="resmimetype">text/microsoft-resx</resheader>
-	<resheader name="version">2.0</resheader>
-	<resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
-	<resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
-	<data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
-	<data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
-	<data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
-		<value>[base64 mime encoded serialized .NET Framework object]</value>
-	</data>
-	<data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
-		<value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
-		<comment>This is a comment</comment>
-	</data>
-
-	There are any number of "resheader" rows that contain simple
-	name/value pairs.
-
-	Each data row contains a name, and value. The row also contains a
-	type or mimetype. Type corresponds to a .NET class that support
-	text/value conversion through the TypeConverter architecture.
-	Classes that don't support this are serialized and stored with the
-	mimetype set.
-
-	The mimetype is used for serialized objects, and tells the
-	ResXResourceReader how to depersist the object. This is currently not
-	extensible. For a given mimetype the value must be set accordingly:
-
-	Note - application/x-microsoft.net.object.binary.base64 is the format
-	that the ResXResourceWriter will generate, however the reader can
-	read any of the formats listed below.
-
-	mimetype: application/x-microsoft.net.object.binary.base64
-	value   : The object must be serialized with
-			: System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
-			: and then encoded with base64 encoding.
-
-	mimetype: application/x-microsoft.net.object.soap.base64
-	value   : The object must be serialized with
-			: System.Runtime.Serialization.Formatters.Soap.SoapFormatter
-			: and then encoded with base64 encoding.
-
-	mimetype: application/x-microsoft.net.object.bytearray.base64
-	value   : The object must be serialized into a byte array
-			: using a System.ComponentModel.TypeConverter
-			: and then encoded with base64 encoding.
-	-->
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
-	<xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
-	<xsd:element name="root" msdata:IsDataSet="true">
-	  <xsd:complexType>
-		<xsd:choice maxOccurs="unbounded">
-		  <xsd:element name="metadata">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" use="required" type="xsd:string" />
-			  <xsd:attribute name="type" type="xsd:string" />
-			  <xsd:attribute name="mimetype" type="xsd:string" />
-			  <xsd:attribute ref="xml:space" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="assembly">
-			<xsd:complexType>
-			  <xsd:attribute name="alias" type="xsd:string" />
-			  <xsd:attribute name="name" type="xsd:string" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="data">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-				<xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
-			  <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
-			  <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
-			  <xsd:attribute ref="xml:space" />
-			</xsd:complexType>
-		  </xsd:element>
-		  <xsd:element name="resheader">
-			<xsd:complexType>
-			  <xsd:sequence>
-				<xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
-			  </xsd:sequence>
-			  <xsd:attribute name="name" type="xsd:string" use="required" />
-			</xsd:complexType>
-		  </xsd:element>
-		</xsd:choice>
-	  </xsd:complexType>
-	</xsd:element>
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
   </xsd:schema>
   <resheader name="resmimetype">
-	<value>text/microsoft-resx</value>
+    <value>text/microsoft-resx</value>
   </resheader>
   <resheader name="version">
-	<value>2.0</value>
+    <value>2.0</value>
   </resheader>
   <resheader name="reader">
-	<value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <resheader name="writer">
-	<value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-	<value>17, 17</value>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
   </metadata>
 </root>

--- a/src/WeSay.ConfigTool/FieldsControl.cs
+++ b/src/WeSay.ConfigTool/FieldsControl.cs
@@ -68,6 +68,15 @@ namespace WeSay.ConfigTool
 
 		}
 
+		public void RefreshFieldDisplayNames()
+		{
+			foreach (ListViewItem item in _fieldsListBox.Items)
+			{
+				Field field = (Field) item.Tag;
+				item.Text = field.DisplayName;
+			}
+		}
+
 		/// <summary>
 		/// Construct the list of fields to show.
 		/// </summary>

--- a/src/WeSay.ConfigTool/SettingsControl.cs
+++ b/src/WeSay.ConfigTool/SettingsControl.cs
@@ -107,6 +107,11 @@ namespace WeSay.ConfigTool
 				_areaHeader.AppendText(button.Text + ": ");
 				_areaHeader.SelectionFont = new Font("Tahoma", 10F, FontStyle.Regular);
 				_areaHeader.AppendText(c.Header);
+				FieldsControl fc = button.Tag as FieldsControl;
+				if (fc != null)
+				{
+					fc.RefreshFieldDisplayNames();
+				}
 				c.Focus();
 
 				UsageReporter.SendNavigationNotice("settings/"+c.NameForUsageReporting);

--- a/src/WeSay.ConfigTool/Tasks/ConfigTaskControlFactory.cs
+++ b/src/WeSay.ConfigTool/Tasks/ConfigTaskControlFactory.cs
@@ -22,6 +22,10 @@ namespace WeSay.ConfigTool.Tasks
 			{
 				return new GatherBySemDomTaskConfigControl(config);
 			}
+			if (config.TaskName == "Dictionary")
+			{
+				return new DictionaryBrowseEditTaskConfigControl(config);
+			}
 			return new DefaultTaskConfigurationControl(config, false);
 		}
 	}

--- a/src/WeSay.ConfigTool/Tasks/DictionaryBrowseEditTaskConfigControl.Designer.cs
+++ b/src/WeSay.ConfigTool/Tasks/DictionaryBrowseEditTaskConfigControl.Designer.cs
@@ -1,0 +1,104 @@
+﻿namespace WeSay.ConfigTool.Tasks
+{
+	partial class DictionaryBrowseEditTaskConfigControl
+	{
+		/// <summary>
+		/// Required designer variable.
+		/// </summary>
+		private System.ComponentModel.IContainer components = null;
+
+		/// <summary>
+		/// Clean up any resources being used.
+		/// </summary>
+		/// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		#region Component Designer generated code
+
+		/// <summary>
+		/// Required method for Designer support - do not modify
+		/// the contents of this method with the code editor.
+		/// </summary>
+		private void InitializeComponent()
+		{
+			this._definition = new System.Windows.Forms.RadioButton();
+			this._storeMeaning = new System.Windows.Forms.GroupBox();
+			this._gloss = new System.Windows.Forms.RadioButton();
+			this._storeMeaning.SuspendLayout();
+			this.SuspendLayout();
+			//
+			// _setupLabel
+			//
+			this._setupLabel.Enabled = false;
+			this._setupLabel.Location = new System.Drawing.Point(84, 185);
+			this._setupLabel.Size = new System.Drawing.Size(94, 13);
+			this._setupLabel.Text = "Meaning Field: ";
+			//
+			// _definition
+			//
+			this._definition.AutoSize = true;
+			this._definition.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this._definition.Location = new System.Drawing.Point(16, 19);
+			this._definition.Name = "_definition";
+			this._definition.Size = new System.Drawing.Size(69, 17);
+			this._definition.TabIndex = 24;
+			this._definition.TabStop = true;
+			this._definition.Text = "Definition";
+			this._definition.UseVisualStyleBackColor = true;
+			this._definition.Click += new System.EventHandler(this.OnDefinition_RadioClicked);
+			//
+			// _storeMeaning
+			//
+			this._storeMeaning.Controls.Add(this._gloss);
+			this._storeMeaning.Controls.Add(this._definition);
+			this._storeMeaning.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this._storeMeaning.Location = new System.Drawing.Point(17, 185);
+			this._storeMeaning.Name = "_storeMeaning";
+			this._storeMeaning.Size = new System.Drawing.Size(377, 78);
+			this._storeMeaning.TabIndex = 25;
+			this._storeMeaning.TabStop = false;
+			this._storeMeaning.Text = "Store Meaning in";
+			//
+			// _gloss
+			//
+			this._gloss.AutoSize = true;
+			this._gloss.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this._gloss.Location = new System.Drawing.Point(16, 43);
+			this._gloss.Name = "_gloss";
+			this._gloss.Size = new System.Drawing.Size(276, 17);
+			this._gloss.TabIndex = 25;
+			this._gloss.TabStop = true;
+			this._gloss.Text = "Gloss (preferred choice when sharing data with FLEx)";
+			this._gloss.UseVisualStyleBackColor = true;
+			this._gloss.CheckedChanged += new System.EventHandler(this.OnGloss_RadioClicked);
+			//
+			// DictionaryBrowseEditTaskConfigControl
+			//
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.Controls.Add(this._storeMeaning);
+			this.Name = "DictionaryBrowseEditTaskConfigControl";
+			this.Size = new System.Drawing.Size(488, 289);
+			this.Controls.SetChildIndex(this._setupLabel, 0);
+			this.Controls.SetChildIndex(this._storeMeaning, 0);
+			this._storeMeaning.ResumeLayout(false);
+			this._storeMeaning.PerformLayout();
+			this.ResumeLayout(false);
+			this.PerformLayout();
+
+		}
+
+		#endregion
+
+		private System.Windows.Forms.RadioButton _definition;
+		private System.Windows.Forms.GroupBox _storeMeaning;
+		private System.Windows.Forms.RadioButton _gloss;
+	}
+}

--- a/src/WeSay.ConfigTool/Tasks/DictionaryBrowseEditTaskConfigControl.cs
+++ b/src/WeSay.ConfigTool/Tasks/DictionaryBrowseEditTaskConfigControl.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using WeSay.LexicalTools.DictionaryBrowseAndEdit;
+using WeSay.Project;
+
+namespace WeSay.ConfigTool.Tasks
+{
+	public partial class DictionaryBrowseEditTaskConfigControl : DefaultTaskConfigurationControl
+	{
+		public DictionaryBrowseEditTaskConfigControl(ITaskConfiguration config)
+			: base(config, true)
+		{
+			InitializeComponent();
+			switch (Configuration.MeaningField)
+			{
+				case "definition":
+					_definition.Checked = true;
+					break;
+				case "gloss":
+					_gloss.Checked = true;
+					break;
+			}
+		}
+
+		private DictionaryBrowseAndEditConfiguration Configuration
+		{
+			get
+			{
+				return (DictionaryBrowseAndEditConfiguration)_config;
+			}
+		}
+
+		private void OnGloss_RadioClicked(object sender, EventArgs e)
+		{
+			Configuration.MeaningField = "gloss";
+		}
+
+		private void OnDefinition_RadioClicked(object sender, EventArgs e)
+		{
+			Configuration.MeaningField = "definition";
+		}
+
+	}
+}

--- a/src/WeSay.ConfigTool/Tasks/DictionaryBrowseEditTaskConfigControl.cs
+++ b/src/WeSay.ConfigTool/Tasks/DictionaryBrowseEditTaskConfigControl.cs
@@ -32,11 +32,13 @@ namespace WeSay.ConfigTool.Tasks
 		private void OnGloss_RadioClicked(object sender, EventArgs e)
 		{
 			Configuration.MeaningField = "gloss";
+			WeSayWordsProject.Project.MakeMeaningFieldChange("definition", "gloss");
 		}
 
 		private void OnDefinition_RadioClicked(object sender, EventArgs e)
 		{
 			Configuration.MeaningField = "definition";
+			WeSayWordsProject.Project.MakeMeaningFieldChange("gloss", "definition");
 		}
 
 	}

--- a/src/WeSay.ConfigTool/Tasks/DictionaryBrowseEditTaskConfigControl.resx
+++ b/src/WeSay.ConfigTool/Tasks/DictionaryBrowseEditTaskConfigControl.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/src/WeSay.ConfigTool/Tasks/TaskListPresentationModel.cs
+++ b/src/WeSay.ConfigTool/Tasks/TaskListPresentationModel.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Autofac;
 using Palaso.WritingSystems;
-using WeSay.Project;
 using WeSay.Project;
 
 namespace WeSay.ConfigTool.Tasks
@@ -26,35 +26,9 @@ namespace WeSay.ConfigTool.Tasks
 
 		private void OnProject_WritingSystemDeleted(object sender, WritingSystemDeletedEventArgs e)
 		{
-			foreach (var task in ICareThatWritingSystemIdChangedTasks)
+			foreach (var task in Tasks.OfType<ICareThatWritingSystemIdChanged>())
 			{
 				task.OnWritingSystemIdDeleted(e.Id);
-			}
-		}
-
-		private IEnumerable<ICareThatWritingSystemIdChanged> ICareThatWritingSystemIdChangedTasks
-		{
-			get
-			{
-				foreach (object task in Tasks)
-				{
-					if (null == task as ICareThatWritingSystemIdChanged)
-						continue;
-					yield return ((ICareThatWritingSystemIdChanged) task);
-				}
-			}
-		}
-
-		private IEnumerable<ICareThatMeaningFieldChanged> ICareThatMeaningFieldChangedTasks
-		{
-			get
-			{
-				foreach (object task in Tasks)
-				{
-					if (null == task as ICareThatMeaningFieldChanged)
-						continue;
-					yield return ((ICareThatMeaningFieldChanged)task);
-				}
 			}
 		}
 
@@ -66,7 +40,7 @@ namespace WeSay.ConfigTool.Tasks
 
 		private void OnProject_WritingSystemChanged(object sender, WeSayWordsProject.StringPair pair)
 		{
-			foreach (var task in ICareThatWritingSystemIdChangedTasks)
+			foreach (var task in Tasks.OfType<ICareThatWritingSystemIdChanged>())
 			{
 				task.OnWritingSystemIdChanged(pair.from, pair.to);
 			}
@@ -74,12 +48,11 @@ namespace WeSay.ConfigTool.Tasks
 
 		private void OnProject_MeaningFieldChanged(object sender, WeSayWordsProject.StringPair pair)
 		{
-			foreach (var task in ICareThatMeaningFieldChangedTasks)
+			foreach (var task in Tasks.OfType<ICareThatMeaningFieldChanged>())
 			{
 				task.OnMeaningFieldChanged(pair.from, pair.to);
 			}
 		}
-
 
 		public bool DoShowTask(ITaskConfiguration task)
 		{

--- a/src/WeSay.ConfigTool/Tasks/TaskListPresentationModel.cs
+++ b/src/WeSay.ConfigTool/Tasks/TaskListPresentationModel.cs
@@ -20,6 +20,8 @@ namespace WeSay.ConfigTool.Tasks
 
 			WeSayWordsProject.Project.WritingSystemChanged += OnProject_WritingSystemChanged;
 			WeSayWordsProject.Project.WritingSystemDeleted += OnProject_WritingSystemDeleted;
+
+			WeSayWordsProject.Project.MeaningFieldChanged += OnProject_MeaningFieldChanged;
 		}
 
 		private void OnProject_WritingSystemDeleted(object sender, WritingSystemDeletedEventArgs e)
@@ -43,6 +45,19 @@ namespace WeSay.ConfigTool.Tasks
 			}
 		}
 
+		private IEnumerable<ICareThatMeaningFieldChanged> ICareThatMeaningFieldChangedTasks
+		{
+			get
+			{
+				foreach (object task in Tasks)
+				{
+					if (null == task as ICareThatMeaningFieldChanged)
+						continue;
+					yield return ((ICareThatMeaningFieldChanged)task);
+				}
+			}
+		}
+
 		public IEnumerable<ITaskConfiguration> Tasks
 		{
 			get { return _taskCollection; }
@@ -56,6 +71,15 @@ namespace WeSay.ConfigTool.Tasks
 				task.OnWritingSystemIdChanged(pair.from, pair.to);
 			}
 		}
+
+		private void OnProject_MeaningFieldChanged(object sender, WeSayWordsProject.StringPair pair)
+		{
+			foreach (var task in ICareThatMeaningFieldChangedTasks)
+			{
+				task.OnMeaningFieldChanged(pair.from, pair.to);
+			}
+		}
+
 
 		public bool DoShowTask(ITaskConfiguration task)
 		{

--- a/src/WeSay.ConfigTool/WeSay.ConfigTool.csproj
+++ b/src/WeSay.ConfigTool/WeSay.ConfigTool.csproj
@@ -115,8 +115,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\lib\common\Mono.Addins.dll</HintPath>
     </Reference>
-    <Reference Condition="'$(OS)'!='Windows_NT'" Include="Geckofx-Core"/>
-    <Reference Condition="'$(OS)'!='Windows_NT'" Include="Geckofx-Winforms"/>
+    <Reference Condition="'$(OS)'!='Windows_NT'" Include="Geckofx-Core" />
+    <Reference Condition="'$(OS)'!='Windows_NT'" Include="Geckofx-Winforms" />
     <None Include="\usr\lib\cli\geckofx-29\Geckofx-Core.dll.config" Condition="'$(OS)'!='Windows_NT'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -287,6 +287,10 @@
       <SubType>Designer</SubType>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <EmbeddedResource Include="Tasks\DictionaryBrowseEditTaskConfigControl.resx">
+      <DependentUpon>DictionaryBrowseEditTaskConfigControl.cs</DependentUpon>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
     <EmbeddedResource Include="Tasks\GatherBySemDomTaskConfigControl.resx">
       <DependentUpon>GatherBySemDomTaskConfigControl.cs</DependentUpon>
       <SubType>Designer</SubType>
@@ -343,6 +347,12 @@
       <DesignTimeSharedInput>True</DesignTimeSharedInput>
     </Compile>
     <Compile Include="Properties\Settings.cs" />
+    <Compile Include="Tasks\DictionaryBrowseEditTaskConfigControl.cs">
+      <SubType>UserControl</SubType>
+    </Compile>
+    <Compile Include="Tasks\DictionaryBrowseEditTaskConfigControl.Designer.cs">
+      <DependentUpon>DictionaryBrowseEditTaskConfigControl.cs</DependentUpon>
+    </Compile>
     <Compile Include="Tasks\GatherBySemDomTaskConfigControl.cs">
       <SubType>UserControl</SubType>
     </Compile>

--- a/src/WeSay.Data.Tests/WeSay.Data.Tests.csproj
+++ b/src/WeSay.Data.Tests/WeSay.Data.Tests.csproj
@@ -119,4 +119,7 @@
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
 </Project>

--- a/src/WeSay.Project.Tests/ConfigFileTests.cs
+++ b/src/WeSay.Project.Tests/ConfigFileTests.cs
@@ -50,7 +50,7 @@ namespace WeSay.Project.Tests
 								  GetV7ConfigFileContent());
 			var configFile = new ConfigFile(pathToConfigFile);
 			configFile.MigrateIfNecassary();
-			Assert.That(configFile.Version, Is.EqualTo(8));
+			Assert.That(configFile.Version, Is.EqualTo(ConfigFile.LatestVersion));
 		}
 
 		[Test]

--- a/src/WeSay.Project.Tests/ConfigMigration/WeSayConfig/WeSayConfigMigrationTests.cs
+++ b/src/WeSay.Project.Tests/ConfigMigration/WeSayConfig/WeSayConfigMigrationTests.cs
@@ -183,13 +183,46 @@ namespace WeSay.Project.Tests.ConfigMigration.WeSayConfig
 		[Test]
 		public void DoesMigrateV6File()
 		{
+
 			File.WriteAllText(_pathToInputConfig,
 			@"<?xml version='1.0' encoding='utf-8'?>
-			<configuration version='5'>
+			<configuration version='6'>
 				<components>
 					<viewTemplate></viewTemplate>
 				</components>
 				<tasks><task id='Dashboard' class='WeSay.LexicalTools.Dashboard.DashboardControl' assembly='CommonTools' default='true'></task></tasks>
+			</configuration>");
+			bool didMigrate = _migrator.MigrateConfigurationXmlIfNeeded(_pathToInputConfig, _outputPath);
+			Assert.IsTrue(didMigrate);
+			AssertHasAtLeastOneMatch(_queryToCheckConfigVersion, _outputPath);
+		}
+
+		[Test]
+		public void DoesMigrateV7File()
+		{
+			File.WriteAllText(_pathToInputConfig,
+			@"<?xml version='1.0' encoding='utf-8'?>
+			<configuration version='7'>
+				<components>
+					<viewTemplate></viewTemplate>
+				</components>
+				<tasks><task id='Dashboard' class='WeSay.LexicalTools.Dashboard.DashboardControl' assembly='CommonTools' default='true'></task></tasks>
+			</configuration>");
+			bool didMigrate = _migrator.MigrateConfigurationXmlIfNeeded(_pathToInputConfig, _outputPath);
+			Assert.IsTrue(didMigrate);
+			AssertHasAtLeastOneMatch(_queryToCheckConfigVersion, _outputPath);
+		}
+
+		[Test]
+		public void DoesMigrateV8File()
+		{
+			File.WriteAllText(_pathToInputConfig,
+			@"<?xml version='1.0' encoding='utf-8'?>
+			<configuration version='6'>
+				<components>
+					<viewTemplate></viewTemplate>
+				</components>
+				<tasks><task id='Dashboard' visible='true'></task></tasks>
 			</configuration>");
 			bool didMigrate = _migrator.MigrateConfigurationXmlIfNeeded(_pathToInputConfig, _outputPath);
 			Assert.IsTrue(didMigrate);
@@ -214,7 +247,7 @@ namespace WeSay.Project.Tests.ConfigMigration.WeSayConfig
 		}
 
 		[Test]
-		public void V7File_ConfigFileIsVersion7_ConvertedToVersion8()
+		public void V7File_ConfigFileIsVersion7_ConvertedToCurrentVersion()
 		{
 			File.WriteAllText(_pathToInputConfig,
 				@"<?xml version='1.0' encoding='utf-8'?>
@@ -227,7 +260,250 @@ namespace WeSay.Project.Tests.ConfigMigration.WeSayConfig
 					</fields>
 				</configuration>");
 			_migrator.MigrateConfigurationXmlIfNeeded(_pathToInputConfig, _outputPath);
-			AssertHasAtLeastOneMatch("//configuration[@version='8']", _outputPath);
+			AssertHasAtLeastOneMatch(String.Format("//configuration[@version='{0}']", ConfigFile.LatestVersion), _outputPath);
+		}
+
+		[Test]
+		public void V9File_MeaningFieldAddedToDictionaryTask()
+		{
+			File.WriteAllText(
+				_pathToInputConfig,
+				@"<?xml version='1.0' encoding='utf-8'?>
+				<configuration version='8'>
+					<components>
+						<viewTemplate></viewTemplate>
+					</components>
+					<tasks>
+						<task taskName='Dashboard' visible='true'></task>
+						<task taskName='Dictionary' visible='true'></task>
+					</tasks>
+				</configuration>"
+			);
+			_migrator.MigrateConfigurationXmlIfNeeded(_pathToInputConfig, _outputPath);
+			AssertHasAtLeastOneMatch("//task[@taskName='Dictionary']/meaningField[text()='definition']", _outputPath);
+		}
+
+		[Test]
+		public void V9File_MeaningFieldAddedToTemplateFields()
+		{
+			File.WriteAllText(
+				_pathToInputConfig,
+				@"<?xml version='1.0' encoding='utf-8'?>
+				<configuration version='8'>
+					<components>
+						<viewTemplate>
+						  <fields>
+							<field>
+							  <className>LexEntry</className>
+							  <dataType>MultiText</dataType>
+							  <displayName>Word</displayName>
+							  <enabled>True</enabled>
+							  <fieldName>EntryLexicalForm</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>False</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <visibility>Visible</visibility>
+							  <writingSystems>
+								<id>qaa-x-qaa</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexEntry</className>
+							  <dataType>MultiText</dataType>
+							  <displayName>Citation Form</displayName>
+							  <enabled>False</enabled>
+							  <fieldName>citation</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>False</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <visibility>NormallyHidden</visibility>
+							  <writingSystems>
+								<id>qaa-x-qaa</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexSense</className>
+							  <dataType>MultiText</dataType>
+							  <displayName>Definition (Meaning)</displayName>
+							  <enabled>True</enabled>
+							  <fieldName>definition</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>True</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <visibility>Visible</visibility>
+							  <writingSystems>
+								<id>en</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexSense</className>
+							  <dataType>MultiText</dataType>
+							  <displayName>Gloss</displayName>
+							  <enabled>False</enabled>
+							  <fieldName>gloss</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>True</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <visibility>NormallyHidden</visibility>
+							  <writingSystems>
+								<id>en</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexEntry</className>
+							  <dataType>MultiText</dataType>
+							  <displayName>Literal Meaning</displayName>
+							  <enabled>False</enabled>
+							  <fieldName>literal-meaning</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>True</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <visibility>NormallyHidden</visibility>
+							  <writingSystems>
+								<id>en</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>PalasoDataObject</className>
+							  <dataType>MultiText</dataType>
+							  <displayName>Note</displayName>
+							  <enabled>True</enabled>
+							  <fieldName>note</fieldName>
+							  <multiParagraph>True</multiParagraph>
+							  <spellCheckingEnabled>True</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <visibility>NormallyHidden</visibility>
+							  <writingSystems>
+								<id>en</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexSense</className>
+							  <dataType>Picture</dataType>
+							  <displayName>Picture</displayName>
+							  <enabled>True</enabled>
+							  <fieldName>Picture</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>False</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <visibility>NormallyHidden</visibility>
+							  <writingSystems>
+								<id>en</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexSense</className>
+							  <dataType>Option</dataType>
+							  <displayName>PartOfSpeech</displayName>
+							  <enabled>True</enabled>
+							  <fieldName>POS</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>False</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <optionsListFile>PartsOfSpeech.xml</optionsListFile>
+							  <visibility>Visible</visibility>
+							  <writingSystems>
+								<id>en</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexSense</className>
+							  <dataType>MultiText</dataType>
+							  <displayName>SILCAWL</displayName>
+							  <enabled>False</enabled>
+							  <fieldName>SILCAWL</fieldName>
+							  <multiParagraph>True</multiParagraph>
+							  <spellCheckingEnabled>False</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <visibility>NormallyHidden</visibility>
+							  <writingSystems>
+								<id>en</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexExampleSentence</className>
+							  <dataType>MultiText</dataType>
+							  <displayName>Example Sentence</displayName>
+							  <enabled>True</enabled>
+							  <fieldName>ExampleSentence</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>True</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <visibility>Visible</visibility>
+							  <writingSystems>
+								<id>qaa-x-qaa</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexExampleSentence</className>
+							  <dataType>MultiText</dataType>
+							  <displayName>Example Translation</displayName>
+							  <enabled>False</enabled>
+							  <fieldName>ExampleTranslation</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>True</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <visibility>Visible</visibility>
+							  <writingSystems>
+								<id>en</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexSense</className>
+							  <dataType>OptionCollection</dataType>
+							  <displayName>Sem Dom</displayName>
+							  <enabled>True</enabled>
+							  <fieldName>semantic-domain-ddp4</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>False</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <optionsListFile>Ddp4.xml</optionsListFile>
+							  <visibility>NormallyHidden</visibility>
+							  <writingSystems>
+								<id>en</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexEntry</className>
+							  <dataType>RelationToOneEntry</dataType>
+							  <displayName>Base Form</displayName>
+							  <enabled>False</enabled>
+							  <fieldName>BaseForm</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>False</spellCheckingEnabled>
+							  <multiplicity>ZeroOr1</multiplicity>
+							  <visibility>NormallyHidden</visibility>
+							  <writingSystems>
+								<id>qaa-x-qaa</id>
+							  </writingSystems>
+							</field>
+							<field>
+							  <className>LexEntry</className>
+							  <dataType>RelationToOneEntry</dataType>
+							  <displayName>Cross Reference</displayName>
+							  <enabled>False</enabled>
+							  <fieldName>confer</fieldName>
+							  <multiParagraph>False</multiParagraph>
+							  <spellCheckingEnabled>False</spellCheckingEnabled>
+							  <multiplicity>ZeroOrMore</multiplicity>
+							  <visibility>NormallyHidden</visibility>
+							  <writingSystems>
+								<id>qaa-x-qaa</id>
+							  </writingSystems>
+							</field>
+						  </fields>
+						  <id>Default View Template</id>
+						</viewTemplate>
+					</components>
+					<tasks>
+						<task taskName='Dashboard' visible='true'></task>
+						<task taskName='Dictionary' visible='true'></task>
+					</tasks>
+				</configuration>"
+			);
+			_migrator.MigrateConfigurationXmlIfNeeded(_pathToInputConfig, _outputPath);
+			AssertHasAtLeastOneMatch("//field[fieldName='gloss' and meaningField='False']", _outputPath);
+			AssertHasAtLeastOneMatch("//field[fieldName='definition' and meaningField='True']", _outputPath);
 		}
 
 		[Test]
@@ -235,7 +511,7 @@ namespace WeSay.Project.Tests.ConfigMigration.WeSayConfig
 		{
 			File.WriteAllText(
 				_pathToInputConfig,
-				"<?xml version='1.0' encoding='utf-8'?><configuration version='8'></configuration>"
+				String.Format("<?xml version='1.0' encoding='utf-8'?><configuration version='{0}'></configuration>", ConfigFile.LatestVersion)
 			);
 			bool didMigrate = _migrator.MigrateConfigurationXmlIfNeeded(_pathToInputConfig, _outputPath);
 			Assert.IsFalse(didMigrate);

--- a/src/WeSay.Project.Tests/WeSay.Project.Tests.csproj
+++ b/src/WeSay.Project.Tests/WeSay.Project.Tests.csproj
@@ -158,6 +158,10 @@
       <Project>{5F61C809-B6C0-4567-9603-B2198E1AD038}</Project>
       <Name>LexicalModel</Name>
     </ProjectReference>
+    <ProjectReference Include="..\LexicalTools\LexicalTools.csproj">
+      <Project>{87af0b02-2983-486d-857f-d1859535c234}</Project>
+      <Name>LexicalTools</Name>
+    </ProjectReference>
     <ProjectReference Include="..\WeSay.Data\WeSay.Data.csproj">
       <Project>{600D0FD4-D189-41A0-9BC5-FC79AD2CF1CD}</Project>
       <Name>WeSay.Data</Name>

--- a/src/WeSay.Project.Tests/WeSay.Project.Tests.csproj
+++ b/src/WeSay.Project.Tests/WeSay.Project.Tests.csproj
@@ -194,6 +194,9 @@
       <LastGenOutput>TestResources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	   Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/WeSay.Project.Tests/WeSayWordsProjectTests.cs
+++ b/src/WeSay.Project.Tests/WeSayWordsProjectTests.cs
@@ -1131,10 +1131,9 @@ namespace WeSay.Project.Tests
 
 		private void VerifyTasks(IEnumerable<ITaskConfiguration> taskconfigs, string meaningField)
 		{
+			// want to assert the following changes
 			// dictionary task meaningfield
-			//		hopefully this will be set
 			// MissingInfo tasks have changed
-			//		hopefully this will be set
 			bool dict = false, meanings = false, pos = false, exsent = false;
 			Assert.NotNull(taskconfigs);
 			foreach (object task in taskconfigs)

--- a/src/WeSay.Project.Tests/WeSayWordsProjectTests.cs
+++ b/src/WeSay.Project.Tests/WeSayWordsProjectTests.cs
@@ -1120,12 +1120,9 @@ namespace WeSay.Project.Tests
 		private void OnProject_MeaningFieldChanged(object sender, WeSayWordsProject.StringPair pair)
 		{
 			var project = sender as WeSayWordsProject;
-			foreach (var task in project.TaskConfigurations)
+			foreach (var task in project.TaskConfigurations.OfType<ICareThatMeaningFieldChanged>())
 			{
-				var mf = task as ICareThatMeaningFieldChanged;
-				if (null == mf)
-					continue;
-				mf.OnMeaningFieldChanged(pair.from, pair.to);
+				task.OnMeaningFieldChanged(pair.from, pair.to);
 			}
 		}
 
@@ -1140,13 +1137,13 @@ namespace WeSay.Project.Tests
 			{
 				Assert.NotNull(task);
 
-				if (null != task as DictionaryBrowseAndEditConfiguration)
+				DictionaryBrowseAndEditConfiguration dbe = task as DictionaryBrowseAndEditConfiguration;
+				if (dbe != null)
 				{
-					DictionaryBrowseAndEditConfiguration dbe = (DictionaryBrowseAndEditConfiguration)task;
-					System.Console.WriteLine("dbe: checking meaningField");
 					Assert.AreEqual(meaningField, dbe.MeaningField);
 					dict = true;
 				}
+
 				MissingInfoConfiguration missinginfo = task as MissingInfoConfiguration;
 				if (missinginfo != null)
 				{

--- a/src/WeSay.Project.Tests/WeSayWordsProjectTests.cs
+++ b/src/WeSay.Project.Tests/WeSayWordsProjectTests.cs
@@ -1114,5 +1114,48 @@ namespace WeSay.Project.Tests
 				Assert.That(project.PathToLiftFile, Is.EqualTo(e.PathToLiftFile));
 			}
 		}
+
+		[Test]
+		public void ChangeMeaningFieldToGloss()
+		{
+			using (var e = new ProjectDirectorySetupForTesting(""))
+			{
+				var project = new WeSayWordsProject();
+				project.LoadFromProjectDirectoryPath(e.PathToDirectory);
+				project.MakeMeaningFieldChange("definition", "gloss");
+
+				// want to assert the following changes
+
+				// field and gloss field configs have changed
+				// field:meaningField exists
+				ViewTemplate template = project.DefaultViewTemplate;
+				Assert.IsNotNull(template);
+
+				Field def = project.DefaultViewTemplate.GetField(LexSense.WellKnownProperties.Definition);
+				Field gloss = project.DefaultViewTemplate.GetField(LexSense.WellKnownProperties.Gloss);
+
+				Assert.AreEqual("Definition", def.DisplayName);
+				Assert.AreEqual(false, def.IsMeaningField);
+				Assert.AreEqual(false, def.Enabled);
+				Assert.AreEqual(CommonEnumerations.VisibilitySetting.NormallyHidden, def.Visibility);
+
+				Assert.AreEqual("Gloss (Meaning)", gloss.DisplayName);
+				Assert.AreEqual(true, gloss.IsMeaningField);
+				Assert.AreEqual(true, gloss.Enabled);
+				Assert.AreEqual(CommonEnumerations.VisibilitySetting.Visible, gloss.Visibility);
+
+
+				// dictionary task meaningfield
+				//		hopefully this will be set
+				// MissingInfo tasks have changed
+				//		hopefully this will be set
+			}
+		}
+
+		[Test]
+		public void ChangeMeaningFieldToGlossAndBackToDefinition()
+		{
+
+		}
 	}
 }

--- a/src/WeSay.Project/ConfigFile.cs
+++ b/src/WeSay.Project/ConfigFile.cs
@@ -20,7 +20,7 @@ namespace WeSay.Project
 
 	public class ConfigFile
 	{
-		public const int LatestVersion = 8;
+		public const int LatestVersion = 9;
 		private readonly XmlDocument _xmlDocument = new XmlDocument();
 
 		private string _configFilePath;

--- a/src/WeSay.Project/ConfigMigration/WeSayConfig/ConfigurationMigrator.cs
+++ b/src/WeSay.Project/ConfigMigration/WeSayConfig/ConfigurationMigrator.cs
@@ -67,6 +67,12 @@ namespace WeSay.Project.ConfigMigration.WeSayConfig
 			if (configurationDoc.CreateNavigator().SelectSingleNode("configuration[@version='7']") != null)
 			{
 				MigrateInCode(configurationDoc, targetPath);
+				configurationDoc = new XPathDocument(targetPath);
+				didMigrate = true;
+			}
+			if (configurationDoc.CreateNavigator().SelectSingleNode("configuration[@version='8']") != null)
+			{
+				MigrateUsingXSLT(configurationDoc, "MigrateConfig8To9.xsl", targetPath);
 				//configurationDoc = new XPathDocument(targetPath);
 				didMigrate = true;
 			}

--- a/src/WeSay.Project/ConfigMigration/WeSayConfig/MigrateConfig8To9.xsl
+++ b/src/WeSay.Project/ConfigMigration/WeSayConfig/MigrateConfig8To9.xsl
@@ -1,0 +1,54 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<!-- don't do anything to other versions -->
+	<xsl:template match="configuration[@version='8']">
+		<configuration version="9">
+			<xsl:apply-templates mode ="Migrate8To9"/>
+		</configuration>
+	</xsl:template>
+
+	<xsl:template match="@*|node()" mode="Migrate8To9">
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()"  mode="Migrate8To9"/>
+		</xsl:copy>
+	</xsl:template>
+
+	<xsl:template match="@*|node()" mode="identity">
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()"  mode="identity"/>
+		</xsl:copy>
+	</xsl:template>
+
+	<!-- ============= actual changing starts here ================ -->
+	<xsl:template match="task[@taskName='Dictionary']" mode="Migrate8To9">
+		<task taskName="Dictionary">
+			<xsl:attribute name="visible">
+				<xsl:value-of select="current()/@visible"/>
+			</xsl:attribute>
+			<meaningField>definition</meaningField>
+		</task>
+	</xsl:template>
+
+	<xsl:template match="fields/field" mode="Migrate8To9">
+		<field>
+		<xsl:copy-of select="./*"/>
+		<xsl:choose>
+			<xsl:when test="current()/fieldName='definition'">
+				<meaningField>True</meaningField>
+			</xsl:when>
+			<xsl:otherwise>
+				<meaningField>False</meaningField>
+			</xsl:otherwise>
+		</xsl:choose>
+		</field>
+	</xsl:template>
+<!--
+	<xsl:template match="fields/field" mode="Migrate8To9">
+		<field>
+			<xsl:apply-templates>
+				<xsl:sort select="name()"/>
+			</xsl:apply-templates>
+		</field>
+	</xsl:template>
+-->
+</xsl:stylesheet>

--- a/src/WeSay.Project/ITaskConfiguration.cs
+++ b/src/WeSay.Project/ITaskConfiguration.cs
@@ -29,4 +29,10 @@ namespace WeSay.Project
 		void OnWritingSystemIdChanged(string from, string to);
 		void OnWritingSystemIdDeleted(string id);
 	}
+
+	public interface ICareThatMeaningFieldChanged
+	{
+		void OnMeaningFieldChanged(string from, string to);
+	}
+
 }

--- a/src/WeSay.Project/ViewTemplate.cs
+++ b/src/WeSay.Project/ViewTemplate.cs
@@ -214,14 +214,12 @@ namespace WeSay.Project
 			//we switch from "meaning" being the gloss, to the definition, making Definition
 			//a non-optional field, and gloss a normally hidden field
 
-
 			Field def = GetField(LexSense.WellKnownProperties.Definition);
+			Field gloss = GetField(LexSense.WellKnownProperties.Gloss);
 
 			// In June 2017 the option was put in to have the meaning field be the gloss
 			// so disabling this code (pending removal once thie change is complete)
 			/*
-			Field gloss = GetField(LexSense.WellKnownProperties.Gloss);
-
 			//this is an upgrade situation
 			if (!def.Enabled || def.Visibility != CommonEnumerations.VisibilitySetting.Visible)
 			{
@@ -371,7 +369,7 @@ namespace WeSay.Project
 							  "The label for the field showing the definition of the word.");
 			definitionField.DisplayName = "Definition (Meaning)";
 			definitionField.Description =
-					"The definition of this sense of the word, in one or more languages. Shows up next to the Meaning label.";
+					"The definition of this sense of the word, in one or more languages.";
 			definitionField.Visibility = CommonEnumerations.VisibilitySetting.Visible;
 			definitionField.Enabled = true;
 			definitionField.IsMeaningField = true;
@@ -606,34 +604,58 @@ namespace WeSay.Project
 			}
 		}
 
+		internal string RemoveMeaning(string displayname)
+		{
+			if (displayname.EndsWith(" (Meaning)"))
+			{
+				int index = displayname.IndexOf(" (Meaning)");
+				return displayname.Remove(index);
+			}
+			else return displayname;
+		}
+
+		internal string AddMeaning(string displayname)
+		{
+			if (!displayname.EndsWith(" (Meaning)"))
+			{
+				return displayname + " (Meaning)";
+			}
+			else return displayname;
+		}
+
 		public void OnMeaningFieldChange(string meaningField)
 		{
 			Field def = GetField(LexSense.WellKnownProperties.Definition);
 			Field gloss = GetField(LexSense.WellKnownProperties.Gloss);
 
-			def.DisplayName = "Description";
+			// reset description to remove text about it being the meaning field
 			def.Description =
 		"The definition of this sense of the word, in one or more languages.";
-			gloss.DisplayName = "Gloss";
-			gloss.Description = "Normally a single word, used when interlinearizing texts.";
 
 			switch (meaningField)
 			{
 				case "definition":
+					def.DisplayName = AddMeaning(def.DisplayName);
 					def.Visibility = CommonEnumerations.VisibilitySetting.Visible;
 					def.IsMeaningField = true;
+					def.Enabled = true;
+					gloss.DisplayName = RemoveMeaning(gloss.DisplayName);
 					gloss.Visibility = CommonEnumerations.VisibilitySetting.NormallyHidden;
 					gloss.IsMeaningField = false;
-					def.Enabled = true;
+					gloss.Enabled = false;
 					break;
 				case "gloss":
+					def.DisplayName = RemoveMeaning(def.DisplayName);
 					def.Visibility = CommonEnumerations.VisibilitySetting.NormallyHidden;
 					def.IsMeaningField = false;
+					def.Enabled = false;
+					gloss.DisplayName = AddMeaning(gloss.DisplayName);
 					gloss.Visibility = CommonEnumerations.VisibilitySetting.Visible;
 					gloss.IsMeaningField = true;
 					gloss.Enabled = true;
 					break;
 			}
+
 		}
 
 		public bool IsWritingSystemUsedInField(string writingSystemId, string fieldName)

--- a/src/WeSay.Project/ViewTemplate.cs
+++ b/src/WeSay.Project/ViewTemplate.cs
@@ -218,10 +218,10 @@ namespace WeSay.Project
 			Field gloss = GetField(LexSense.WellKnownProperties.Gloss);
 
 			// In June 2017 the option was put in to have the meaning field be the gloss
-			// so disabling this code (pending removal once thie change is complete)
-			/*
+			// so making sure gloss isn't the meaning field before doing it
+
 			//this is an upgrade situation
-			if (!def.Enabled || def.Visibility != CommonEnumerations.VisibilitySetting.Visible)
+			if (!gloss.IsMeaningField && (!def.Enabled || def.Visibility != CommonEnumerations.VisibilitySetting.Visible))
 			{
 				//copy writing systems from glosses
 				foreach (string writingSystemId in gloss.WritingSystemIds)
@@ -234,20 +234,27 @@ namespace WeSay.Project
 			}
 
 			//detect pre-gloss-to-definition switch
-			if (!def.Enabled || def.Visibility != CommonEnumerations.VisibilitySetting.Visible)
+			if (!gloss.IsMeaningField && (!def.Enabled || def.Visibility != CommonEnumerations.VisibilitySetting.Visible))
 			{
 				gloss.Visibility = CommonEnumerations.VisibilitySetting.Invisible;
 			}
 
-			def.Enabled = true;
-			def.Visibility = CommonEnumerations.VisibilitySetting.Visible;
-			*/
-
 
 			// In Feb 2008 we started giving user control over field order, but
 			// certain key fields must be first.
+			if (gloss.IsMeaningField)
+			{
+				gloss.Enabled = true;
+				gloss.Visibility = CommonEnumerations.VisibilitySetting.Visible;
+				MoveToFirstInClass(gloss);
+			}
+			else
+			{
+				def.Enabled = true;
+				def.Visibility = CommonEnumerations.VisibilitySetting.Visible;
+				MoveToFirstInClass(def);
+			}
 
-			MoveToFirstInClass(def);
 			MoveToFirstInClass(GetField(Field.FieldNames.EntryLexicalForm.ToString()));
 			MoveToFirstInClass(GetField(Field.FieldNames.ExampleSentence.ToString()));
 

--- a/src/WeSay.Project/ViewTemplate.cs
+++ b/src/WeSay.Project/ViewTemplate.cs
@@ -211,10 +211,15 @@ namespace WeSay.Project
 			RemoveDuplicateGloss();
 
 			//In Jan 2008 (still in version 1 Preview 3, just a hand-full of users)
-			//we switch from "meaning" being the gloss, to the definition, making Defintion
+			//we switch from "meaning" being the gloss, to the definition, making Definition
 			//a non-optional field, and gloss a normally hidden field
 
+
 			Field def = GetField(LexSense.WellKnownProperties.Definition);
+
+			// In June 2017 the option was put in to have the meaning field be the gloss
+			// so disabling this code (pending removal once thie change is complete)
+			/*
 			Field gloss = GetField(LexSense.WellKnownProperties.Gloss);
 
 			//this is an upgrade situation
@@ -238,9 +243,12 @@ namespace WeSay.Project
 
 			def.Enabled = true;
 			def.Visibility = CommonEnumerations.VisibilitySetting.Visible;
+			*/
+
 
 			// In Feb 2008 we started giving user control over field order, but
 			// certain key fields must be first.
+
 			MoveToFirstInClass(def);
 			MoveToFirstInClass(GetField(Field.FieldNames.EntryLexicalForm.ToString()));
 			MoveToFirstInClass(GetField(Field.FieldNames.ExampleSentence.ToString()));
@@ -366,6 +374,7 @@ namespace WeSay.Project
 					"The definition of this sense of the word, in one or more languages. Shows up next to the Meaning label.";
 			definitionField.Visibility = CommonEnumerations.VisibilitySetting.Visible;
 			definitionField.Enabled = true;
+			definitionField.IsMeaningField = true;
 			definitionField.IsSpellCheckingEnabled = true;
 			masterTemplate.Add(definitionField);
 
@@ -379,6 +388,7 @@ namespace WeSay.Project
 			glossField.Description = "Normally a single word, used when interlinearizing texts.";
 			glossField.Visibility = CommonEnumerations.VisibilitySetting.NormallyHidden;
 			glossField.Enabled = false;
+			glossField.IsMeaningField = false;
 			glossField.IsSpellCheckingEnabled = true;
 			masterTemplate.Add(glossField);
 
@@ -593,6 +603,36 @@ namespace WeSay.Project
 				{
 					field.ChangeWritingSystemId(from, to);
 				}
+			}
+		}
+
+		public void OnMeaningFieldChange(string meaningField)
+		{
+			Field def = GetField(LexSense.WellKnownProperties.Definition);
+			Field gloss = GetField(LexSense.WellKnownProperties.Gloss);
+
+			def.DisplayName = "Description";
+			def.Description =
+		"The definition of this sense of the word, in one or more languages.";
+			gloss.DisplayName = "Gloss";
+			gloss.Description = "Normally a single word, used when interlinearizing texts.";
+
+			switch (meaningField)
+			{
+				case "definition":
+					def.Visibility = CommonEnumerations.VisibilitySetting.Visible;
+					def.IsMeaningField = true;
+					gloss.Visibility = CommonEnumerations.VisibilitySetting.NormallyHidden;
+					gloss.IsMeaningField = false;
+					def.Enabled = true;
+					break;
+				case "gloss":
+					def.Visibility = CommonEnumerations.VisibilitySetting.NormallyHidden;
+					def.IsMeaningField = false;
+					gloss.Visibility = CommonEnumerations.VisibilitySetting.Visible;
+					gloss.IsMeaningField = true;
+					gloss.Enabled = true;
+					break;
 			}
 		}
 

--- a/src/WeSay.Project/WeSay.Project.csproj
+++ b/src/WeSay.Project/WeSay.Project.csproj
@@ -229,6 +229,9 @@
   <ItemGroup>
     <EmbeddedResource Include="ConfigMigration\UserConfig\Migrate1To2.xsl" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="ConfigMigration\WeSayConfig\MigrateConfig8To9.xsl" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	   Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/WeSay.Project/WeSayWordsProject.cs
+++ b/src/WeSay.Project/WeSayWordsProject.cs
@@ -51,6 +51,7 @@ namespace WeSay.Project
 	public class WeSayWordsProject : BasilProject, IFileLocator
 	{
 		private IList<ITask> _tasks;
+		private IEnumerable<ITaskConfiguration> _taskconfigurations;
 		private ViewTemplate _defaultViewTemplate;
 		private IList<ViewTemplate> _viewTemplates;
 		private readonly Dictionary<string, OptionsList> _optionLists;
@@ -97,6 +98,12 @@ namespace WeSay.Project
 		{
 			get { return _tasks; }
 			set { _tasks = value; }
+		}
+
+		internal IEnumerable<ITaskConfiguration> TaskConfigurations
+		{
+			get { return _taskconfigurations; }
+			set { _taskconfigurations = value; }
 		}
 
 		public static bool ProjectExists
@@ -1938,7 +1945,8 @@ namespace WeSay.Project
 		public void LoadTasksFromConfigFile()
 		{
 			ConfigFileReader configReader = _container.Resolve<ConfigFileReader>();
-			Tasks = ConfigFileTaskBuilder.CreateTasks(_container, configReader.GetTasksConfigurations(_container));
+			TaskConfigurations = configReader.GetTasksConfigurations(_container);
+			Tasks = ConfigFileTaskBuilder.CreateTasks(_container, TaskConfigurations);
 		}
 
 		public delegate void ContainerAdder(ContainerBuilder b);

--- a/src/WeSay.Project/WeSayWordsProject.cs
+++ b/src/WeSay.Project/WeSayWordsProject.cs
@@ -83,6 +83,8 @@ namespace WeSay.Project
 		public event EventHandler<StringPair> WritingSystemChanged;
 		public event WritingSystemDeleted WritingSystemDeleted;
 
+		public event EventHandler<StringPair> MeaningFieldChanged;
+
 		public WeSayWordsProject()
 		{
 			_addins = AddinSet.Create(GetAddinNodes, LocateFile);
@@ -1701,6 +1703,21 @@ namespace WeSay.Project
 				p.from = oldId;
 				p.to = newId;
 				WritingSystemChanged(this, p);
+			}
+		}
+
+		public void MakeMeaningFieldChange(string oldId, string newId)
+		{
+			//change meaning field in template
+			DefaultViewTemplate.OnMeaningFieldChange(newId);
+
+			// lets tasks know that meaning field has changed
+			if (MeaningFieldChanged != null)
+			{
+				StringPair p = new StringPair();
+				p.from = oldId;
+				p.to = newId;
+				MeaningFieldChanged(this, p);
 			}
 		}
 

--- a/src/WeSay.UI.Tests/WeSay.UI.Tests.csproj
+++ b/src/WeSay.UI.Tests/WeSay.UI.Tests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -93,8 +93,8 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
-    <Reference Condition="'$(OS)'!='Windows_NT'" Include="Geckofx-Core"/>
-    <Reference Condition="'$(OS)'!='Windows_NT'" Include="Geckofx-Winforms"/>
+    <Reference Condition="'$(OS)'!='Windows_NT'" Include="Geckofx-Core" />
+    <Reference Condition="'$(OS)'!='Windows_NT'" Include="Geckofx-Winforms" />
     <None Include="\usr\lib\cli\geckofx-29\Geckofx-Core.dll.config" Condition="'$(OS)'!='Windows_NT'">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -166,6 +166,9 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.


### PR DESCRIPTION
configuration options for gloss meaning field - it is set in the Dictionary task configuration
includes migration from v8 to v9 of WeSayConfig format, and changes to project.WeSayConfig that happen when you click the radio button
Fields now know if they are the meaning field
new interface ICareThatMeaningFieldChanged to let other tasks know that meaning field has changed

please ask for more details if you need them

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/wesay/12)
<!-- Reviewable:end -->
