### PR TITLE
Feature/presemdom

### DIFF
--- a/src/LexicalModel/Field.cs
+++ b/src/LexicalModel/Field.cs
@@ -304,7 +304,7 @@ namespace WeSay.LexicalModel
 			get
 			{
 				if (_fieldName == FieldNames.EntryLexicalForm.ToString() ||
-					_fieldName == LexSense.WellKnownProperties.Definition ||
+					IsMeaningField ||
 					_fieldName == FieldNames.ExampleSentence.ToString())
 				{
 					return false;

--- a/src/LexicalTools/AddMissingInfo/MissingInfoConfiguration.cs
+++ b/src/LexicalTools/AddMissingInfo/MissingInfoConfiguration.cs
@@ -206,7 +206,24 @@ namespace WeSay.LexicalTools.AddMissingInfo
 				return false;
 
 			if(task.MissingInfoFieldName != MissingInfoFieldName)
-				return false;
+			{
+				// The field of "Add Meanings" will be definition or gloss depending what the meaning field is
+				// the default config has it as definition so must be considered as equivalent to gloss
+				if (task.MissingInfoFieldName == LexSense.WellKnownProperties.Definition)
+				{
+					if (MissingInfoFieldName != LexSense.WellKnownProperties.Gloss)
+						return false;
+				}
+				else if (task.MissingInfoFieldName == LexSense.WellKnownProperties.Gloss)
+				{
+					if (MissingInfoFieldName != LexSense.WellKnownProperties.Definition)
+						return false;
+				}
+				else
+				{
+					return false;
+				}
+			}
 
 			if (task.Label != Label)
 				return false;

--- a/src/LexicalTools/DictionaryBrowseAndEdit/DictionaryControl.cs
+++ b/src/LexicalTools/DictionaryBrowseAndEdit/DictionaryControl.cs
@@ -162,8 +162,8 @@ namespace WeSay.LexicalTools.DictionaryBrowseAndEdit
 		{
 			RegisterFieldWithPicker(Field.FieldNames.EntryLexicalForm.ToString());
 			// show definition instead of gloss if it is meaningfield
-			Field gloss = _viewTemplate.GetField(LexSense.WellKnownProperties.Gloss);
-			if (gloss.IsMeaningField == true)
+			Field defn = _viewTemplate.GetField(LexSense.WellKnownProperties.Definition);
+			if ((defn == null) || defn.IsMeaningField == true)
 			{
 				RegisterFieldWithPicker(LexSense.WellKnownProperties.Definition); //Reversal
 			}

--- a/src/LexicalTools/DictionaryBrowseAndEdit/DictionaryControl.cs
+++ b/src/LexicalTools/DictionaryBrowseAndEdit/DictionaryControl.cs
@@ -161,7 +161,16 @@ namespace WeSay.LexicalTools.DictionaryBrowseAndEdit
 		private void SetupPickerControlWritingSystems()
 		{
 			RegisterFieldWithPicker(Field.FieldNames.EntryLexicalForm.ToString());
-			RegisterFieldWithPicker(LexSense.WellKnownProperties.Gloss); //Reversal
+			// show definition instead of gloss if it is meaningfield
+			Field gloss = _viewTemplate.GetField(LexSense.WellKnownProperties.Gloss);
+			if (gloss.IsMeaningField == true)
+			{
+				RegisterFieldWithPicker(LexSense.WellKnownProperties.Definition); //Reversal
+			}
+			else
+			{
+				RegisterFieldWithPicker(LexSense.WellKnownProperties.Gloss); //Reversal
+			}
 		}
 
 

--- a/src/LexicalTools/Layouter.cs
+++ b/src/LexicalTools/Layouter.cs
@@ -40,6 +40,13 @@ namespace WeSay.LexicalTools
 		private bool _deletable;
 
 		/// <summary>
+		/// true if the gloss is the meaning field
+		/// false if the defninition is the meaning field
+		/// null if it hasn't been checked yet
+		/// </summary>
+		private bool? _glossMeaningField;
+
+		/// <summary>
 		/// Use for establishing relations been this entry and the rest
 		/// </summary>
 		private readonly LexEntryRepository _lexEntryRepository;
@@ -110,6 +117,32 @@ namespace WeSay.LexicalTools
 		}
 
 		/// <summary>
+		/// true if the gloss is the meaning field
+		/// false if the defninition is the meaning field
+		/// </summary>
+		protected bool GlossMeaningField
+		{
+			get
+			{
+				if (_glossMeaningField == null)
+				{
+					Field field = ActiveViewTemplate.GetField(LexSense.WellKnownProperties.Gloss);
+					if (field != null && field.IsMeaningField)
+					{
+						_glossMeaningField = true;
+					}
+					else
+					{
+						_glossMeaningField = false;
+					}
+				}
+				return (bool) _glossMeaningField;
+			}
+			set { _glossMeaningField = value; }
+		}
+
+
+		/// <summary>
 		/// Use for establishing relations been this entry and the rest
 		/// </summary>
 		protected LexEntryRepository RecordListManager
@@ -165,6 +198,7 @@ namespace WeSay.LexicalTools
 			DetailList.MouseEnteredBounds += OnMouseEnteredBounds;
 			DetailList.MouseLeftBounds += OnMouseLeftBounds;
 			ChildLayouts = new List<Layouter>();
+			_glossMeaningField = null;
 		}
 		public void Dispose()
 		{
@@ -388,13 +422,14 @@ namespace WeSay.LexicalTools
 			int rowCount = 0;
 			foreach (Field customField in ActiveViewTemplate.GetCustomFields(target.GetType().Name))
 			{
-#if GlossMeaning
-#else
-				if (customField.FieldName == LexSense.WellKnownProperties.Definition)
+				if (!GlossMeaningField && customField.FieldName == LexSense.WellKnownProperties.Definition)
 				{
 					continue; //already put this in next to "Meaning"
 				}
-#endif
+				else if (GlossMeaningField && customField.FieldName == LexSense.WellKnownProperties.Gloss)
+				{
+					continue; //already put this in next to "Meaning"
+				}
 				rowCount = AddOneCustomField(target,
 											 customField,
 											 insertAtRow + rowCount /*changed feb 2008*/,

--- a/src/LexicalTools/LexEntryLayouter.cs
+++ b/src/LexicalTools/LexEntryLayouter.cs
@@ -141,8 +141,12 @@ namespace WeSay.LexicalTools
 			var sense = (LexSense) sendingLayouter.PdoToLayout;
 			IConfirmDelete confirmation = _confirmDeleteFactory();
 			var deletionStringToLocalize = StringCatalog.Get("This will permanently remove the meaning");
+			var meaningText = (GlossMeaningField ?
+				sense.Gloss.GetBestAlternative(ActiveViewTemplate.GetDefaultWritingSystemForField(LexSense.WellKnownProperties.Gloss).Id) :
+				sense.Definition.GetBestAlternative(ActiveViewTemplate.GetDefaultWritingSystemForField(LexSense.WellKnownProperties.Definition).Id)
+				);
 			confirmation.Message = String.Format("{0} {1}.", deletionStringToLocalize,
-				sense.Definition.GetBestAlternative(ActiveViewTemplate.GetDefaultWritingSystemForField(LexSense.WellKnownProperties.Definition).Id));
+				meaningText);
 			if (!confirmation.DeleteConfirmed)
 			{
 				return;

--- a/src/WeSay.ConfigTool/FieldDetailControl.cs
+++ b/src/WeSay.ConfigTool/FieldDetailControl.cs
@@ -81,7 +81,8 @@ namespace WeSay.ConfigTool
 				FillDataTypeCombo();
 				_writingSystemsControl.CurrentField = value;
 
-				possibleMeaningField.Visible = (_field.FieldName == "definition" || _field.FieldName == "gloss") ? true : false;
+				possibleMeaningField.Visible = (_field.FieldName == LexSense.WellKnownProperties.Definition) ||
+					(_field.FieldName == LexSense.WellKnownProperties.Gloss) ? true : false;
 
 				UpdateDisplay();
 				_displayName.SelectAll();

--- a/src/WeSay.Project/ViewTemplate.cs
+++ b/src/WeSay.Project/ViewTemplate.cs
@@ -650,6 +650,7 @@ namespace WeSay.Project
 					gloss.Visibility = CommonEnumerations.VisibilitySetting.NormallyHidden;
 					gloss.IsMeaningField = false;
 					gloss.Enabled = false;
+					MoveToFirstInClass(def);
 					break;
 				case "gloss":
 					def.DisplayName = RemoveMeaning(def.DisplayName);
@@ -660,6 +661,7 @@ namespace WeSay.Project
 					gloss.Visibility = CommonEnumerations.VisibilitySetting.Visible;
 					gloss.IsMeaningField = true;
 					gloss.Enabled = true;
+					MoveToFirstInClass(gloss);
 					break;
 			}
 


### PR DESCRIPTION
changes to use the selected meaning field in the Dictionary Browse and Edit task (and anything else that uses the Layouter classes)
bug fixes to stop the infinite loop because of UserCanRelocate and duplicated tasks in MissingInfoConfiguration

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/wesay/13)
<!-- Reviewable:end -->
