### PR TITLE
Friendlier message if PDF file is already open

### DIFF
--- a/src/Addin.Transform/PdfDictionary/PdfMaker.cs
+++ b/src/Addin.Transform/PdfDictionary/PdfMaker.cs
@@ -151,7 +151,7 @@ namespace Addin.Transform.PdfDictionary
 
 				progressState.StatusLabel = "Converting XHTML to PDF...";
 
-				PrinceXmlWrapper.CreatePdf(htmlPath, stylesheetPaths, pdfPath);
+				_launchAfterTransform = PrinceXmlWrapper.CreatePdf(htmlPath, stylesheetPaths, pdfPath);
 
 				if (_launchAfterTransform)
 				{

--- a/src/Addin.Transform/PdfDictionary/PrinceXmlWrapper.cs
+++ b/src/Addin.Transform/PdfDictionary/PrinceXmlWrapper.cs
@@ -21,10 +21,11 @@ namespace Addin.Transform.PdfDictionary
 			}
 		}
 
-		public static void CreatePdf(string htmlPath,
+		public static bool CreatePdf(string htmlPath,
 									 IEnumerable<string> styleSheetPaths,
 									 string pdfPath)
 		{
+			bool retval = true;
 			string princePath = GetPrincePath();
 			Prince p;
 			if (File.Exists(princePath))
@@ -48,7 +49,8 @@ namespace Addin.Transform.PdfDictionary
 					string errorString = File.ReadAllText(log.Path);
 					if (errorString.Contains("error: can't open output file: Permission denied"))
 					{
-						Palaso.Reporting.ErrorReport.NotifyUserOfProblem("Could not create the PDF file. Please check if you have the file open already or if you have permission to create the file in the export directory.");
+						Palaso.Reporting.ErrorReport.NotifyUserOfProblem("Sorry! We couldn't generate the PDF file, probably because the old one is still open in your PDF viewer. Close the PDF and then try again. (Permission denied writing to PDF file)");
+						retval = false;
 					}
 					else
 					{
@@ -56,6 +58,7 @@ namespace Addin.Transform.PdfDictionary
 					}
 				}
 			}
+			return retval;
 		}
 
 		private static string GetPrincePath()

--- a/src/Addin.Transform/PdfDictionary/PrinceXmlWrapper.cs
+++ b/src/Addin.Transform/PdfDictionary/PrinceXmlWrapper.cs
@@ -45,7 +45,15 @@ namespace Addin.Transform.PdfDictionary
 			}
 				if(!p.Convert(htmlPath, pdfPath))
 				{
-					throw new ApplicationException(File.ReadAllText(log.Path));
+					string errorString = File.ReadAllText(log.Path);
+					if (errorString.Contains("error: can't open output file: Permission denied"))
+					{
+						Palaso.Reporting.ErrorReport.NotifyUserOfProblem("Could not create the PDF file. Please check if you have the file open already or if you have permission to create the file in the export directory.");
+					}
+					else
+					{
+						throw new ApplicationException(errorString);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
fixes WS-471

particularly needs review for readability of the error message

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/wesay/20)
<!-- Reviewable:end -->
