### PR TITLE
Feature/multiple installed versions

### DIFF
--- a/build/build.common.proj
+++ b/build/build.common.proj
@@ -11,6 +11,20 @@
 		<LifeCycleStage>CANDIDATE</LifeCycleStage>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<ReleaseString Condition="'$(LifeCycleStage)' == 'ALPHA'">-Alpha</ReleaseString>
+		<ReleaseString Condition="'$(LifeCycleStage)' == 'BETA'">-Beta</ReleaseString>
+		<ReleaseString Condition="'$(LifeCycleStage)' == 'CANDIDATE'">-ReleaseCandidate</ReleaseString>
+		<ReleaseString Condition="'$(LifeCycleStage)' == 'STABLE'"></ReleaseString>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'ALPHA'">Alpha Test</ReleaseLabel>
+		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'BETA'">Beta Test</ReleaseLabel>
+		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'CANDIDATE'">Release Candidate</ReleaseLabel>
+		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'STABLE'">Stable Release</ReleaseLabel>
+	</PropertyGroup>
+
 	<Target Name="VersionNumbers">
 		<Message Text="BUILD_NUMBER: $(BUILD_NUMBER)" Importance="high"/>
 

--- a/build/build.common.proj
+++ b/build/build.common.proj
@@ -8,7 +8,7 @@
 		Condition=" '$(teamcity_version)' != '' And '$(OS)'!='Windows_NT'"/>
 
 	<PropertyGroup>
-		<LifeCycleStage>CANDIDATE</LifeCycleStage>
+		<LifeCycleStage Condition="'$(LifeCycleStage)'==''">CANDIDATE</LifeCycleStage>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/build/build.mono.proj
+++ b/build/build.mono.proj
@@ -19,12 +19,12 @@
 		<ApplicationName>WeSay</ApplicationName>
 		<ApplicationNameLC Condition="'$(ApplicationNameLC)' == ''">wesay</ApplicationNameLC>
 		<Configuration>Debug</Configuration>
+		<Constants>$(LifeCycleStage)</Constants>
 		<MONO_PREFIX Condition="'$(MONO_PREFIX)'==''">/usr</MONO_PREFIX>
 	</PropertyGroup>
 
 	<PropertyGroup>
 		<OutputDir>$(RootDir)/output/$(Configuration)</OutputDir>
-
 	</PropertyGroup>
 
 	<Target Name="Build">
@@ -49,7 +49,7 @@
 		<MSBuild
 			Projects="$(RootDir)\src\$(Solution)"
 			Targets="Build"
-			Properties="Configuration=$(Configuration)" />
+			Properties="Configuration=$(Configuration);Constants=$(Constants)" />
 		<Exec Condition="'$(action)' == 'test'"
 			Command="$(MONO_PREFIX)/bin/mono --debug $(MONO_PREFIX)/lib/mono/4.0/nunit-console.exe -noshadow -exclude=SkipOnTeamCity [!P]*.Tests.dll -xml=WeSay.nunit-output.xml"
 			WorkingDirectory="$(RootDir)/output/$(Configuration)"

--- a/build/build.win.proj
+++ b/build/build.win.proj
@@ -31,13 +31,6 @@
 		<OutputDir>$(RootDir)/output/$(Configuration)</OutputDir>
 	</PropertyGroup>
 
-	<PropertyGroup>
-		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'ALPHA'">Alpha Test</ReleaseLabel>
-		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'BETA'">Beta Test</ReleaseLabel>
-		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'CANDIDATE'">Release Candidate</ReleaseLabel>
-		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'STABLE'">Stable Release</ReleaseLabel>
-	</PropertyGroup>
-
 	<ItemGroup>
 		<CSharpFiles
 			Include="$(RootDir)\**\*.cs"
@@ -45,16 +38,8 @@
 		<XmlFiles Include="$(RootDir)\common\**\*.WeSayConfig"/>
 	</ItemGroup>
 
-	<!-- <Target Name="DownloadDistFiles">
-		<MakeDir Directories= "$(RootDir)\External"/>
-		<WebDownload FileUri="https://dl.dropboxusercontent.com/s/599lb0od6shtqqa/WeSay_Helps.chm?dl=1" FileName="$(RootDir)\External\WeSay_Helps.chm"></WebDownload>
-		<WebDownload FileUri="https://dl.dropboxusercontent.com/s/kj91auval00jv90/wesay.helpmap?dl=1" FileName="$(RootDir)\External\wesay.helpmap"></WebDownload>
-	</Target> -->
-
 	<Target Name="Build">
 		<CallTarget Targets="Clean"/>
-		<!-- We are pulling help files from team city now -->
-		<!-- <CallTarget Targets="DownloadDistFiles" /> -->
 		<CallTarget Targets="CopyHelpFilesIntoSourceTree" />
 		<CallTarget Targets="SetAssemblyVersion"/>
 		<CallTarget Targets="Compile"/>
@@ -180,21 +165,6 @@
 		<CallTarget targets="MakeWixForTemplates"/>
 		<CallTarget targets="MakeWixForXulrunner"/>
 	</Target>
-
-	<!-- LifeCycleStage is set, along with the version, in build.common.proj -->
-	<PropertyGroup>
-		<ReleaseString Condition="'$(LifeCycleStage)' == 'ALPHA'">-Alpha</ReleaseString>
-		<ReleaseString Condition="'$(LifeCycleStage)' == 'BETA'">-Beta</ReleaseString>
-		<ReleaseString Condition="'$(LifeCycleStage)' == 'CANDIDATE'">-ReleaseCandidate</ReleaseString>
-		<ReleaseString Condition="'$(LifeCycleStage)' == 'STABLE'"></ReleaseString>
-	</PropertyGroup>
-
-	<PropertyGroup>
-		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'ALPHA'">Alpha Test</ReleaseLabel>
-		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'BETA'">Beta Test</ReleaseLabel>
-		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'CANDIDATE'">Release Candidate</ReleaseLabel>
-		<ReleaseLabel Condition="'$(LifeCycleStage)' == 'STABLE'">Stable Release</ReleaseLabel>
-	</PropertyGroup>
 
 	<Target Name="Installer" DependsOnTargets="Clean; VersionNumbers; MakeWixForDistFiles; Build ">
 		<!-- set the version number in the installer configuration program.  Perhaps there's a way to just send in the variables rather than this brute-force

--- a/src/WeSay.ConfigTool/Program.cs
+++ b/src/WeSay.ConfigTool/Program.cs
@@ -115,7 +115,7 @@ namespace WeSay.ConfigTool
 			if (String.IsNullOrEmpty(helpFilePath))
 			{
 				string commonDataFolder = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-				helpFilePath = Path.Combine(commonDataFolder, Path.Combine("wesay", "WeSay_Helps.chm"));
+				helpFilePath = Path.Combine(commonDataFolder, Path.Combine(Project.BasilProject.WeSaySharedDirectory, "WeSay_Helps.chm"));
 			}
 			if (File.Exists(helpFilePath))
 			{

--- a/src/WeSay.Project/BasilProject.cs
+++ b/src/WeSay.Project/BasilProject.cs
@@ -212,17 +212,16 @@ There are problems in:
 
 		public static string WeSaySharedDirectory
 		{
-			get
-			{
+			get {
 				string dir = "wesay";
 #if ALPHA
-				dir += "-alpha"
+				dir += "-alpha";
 #endif
 #if BETA
-				dir += "-beta"
+				dir += "-beta";
 #endif
 #if CANDIDATE
-				dir += "-rc"
+				dir += "-rc";
 #endif
 				return dir;
 			}

--- a/src/WeSay.Project/BasilProject.cs
+++ b/src/WeSay.Project/BasilProject.cs
@@ -210,6 +210,24 @@ There are problems in:
 			return null;
 		}
 
+		public static string WeSaySharedDirectory
+		{
+			get
+			{
+				string dir = "wesay";
+#if ALPHA
+				dir += "-alpha"
+#endif
+#if BETA
+				dir += "-beta"
+#endif
+#if CANDIDATE
+				dir += "-rc"
+#endif
+				return dir;
+			}
+		}
+
 		public static string ApplicationCommonDirectory
 		{
 			get {
@@ -217,7 +235,7 @@ There are problems in:
 				if (!Directory.Exists(returndir))
 				{
 					string commonpath = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-					returndir = Path.Combine(commonpath, "wesay");
+					returndir = Path.Combine(commonpath, WeSaySharedDirectory);
 				}
 				return returndir;
 			}
@@ -240,7 +258,7 @@ There are problems in:
 				else
 						{
 					string commonpath = Environment.GetFolderPath(Environment.SpecialFolder.CommonApplicationData);
-					shareddir = Path.Combine(commonpath, "wesay");
+					shareddir = Path.Combine(commonpath, WeSaySharedDirectory);
 				}
 				return shareddir;
 			}
@@ -368,10 +386,13 @@ There are problems in:
 			{
 				string versionString = Application.ProductVersion;
 #if ALPHA
-				versionString += " ALPHA";
+				versionString += " -ALPHA";
 #endif
 #if BETA
-				versionString += " BETA";
+				versionString += " -BETA";
+#endif
+#if CANDIDATE
+				versionString += " -RC";
 #endif
 				return versionString;
 			}

--- a/src/WeSay.Project/BasilProject.cs
+++ b/src/WeSay.Project/BasilProject.cs
@@ -221,7 +221,7 @@ There are problems in:
 				dir += "-beta";
 #endif
 #if CANDIDATE
-				dir += "-rc";
+				dir += "-beta";
 #endif
 				return dir;
 			}
@@ -385,13 +385,13 @@ There are problems in:
 			{
 				string versionString = Application.ProductVersion;
 #if ALPHA
-				versionString += " -ALPHA";
+				versionString += " ALPHA";
 #endif
 #if BETA
-				versionString += " -BETA";
+				versionString += " BETA";
 #endif
 #if CANDIDATE
-				versionString += " -RC";
+				versionString += " RC";
 #endif
 				return versionString;
 			}

--- a/src/WeSay.Project/BasilProject.cs
+++ b/src/WeSay.Project/BasilProject.cs
@@ -216,11 +216,9 @@ There are problems in:
 				string dir = "wesay";
 #if ALPHA
 				dir += "-alpha";
-#endif
-#if BETA
+#elif BETA
 				dir += "-beta";
-#endif
-#if CANDIDATE
+#elif CANDIDATE
 				dir += "-beta";
 #endif
 				return dir;
@@ -386,11 +384,9 @@ There are problems in:
 				string versionString = Application.ProductVersion;
 #if ALPHA
 				versionString += " ALPHA";
-#endif
-#if BETA
+#elif BETA
 				versionString += " BETA";
-#endif
-#if CANDIDATE
+#elif CANDIDATE
 				versionString += " RC";
 #endif
 				return versionString;

--- a/src/WeSay.Project/WeSay.Project.csproj
+++ b/src/WeSay.Project/WeSay.Project.csproj
@@ -23,7 +23,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\..\output\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;$(Constants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputType>Library</OutputType>
@@ -37,7 +37,7 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\..\output\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;$(Constants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <OutputType>Library</OutputType>
@@ -50,7 +50,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\..\output\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;$(Release)</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;$(Release);$(Constants)</DefineConstants>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <DebugType>full</DebugType>
     <PlatformTarget>x86</PlatformTarget>
@@ -59,7 +59,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>..\..\output\Release\</OutputPath>
-    <DefineConstants>TRACE;$(Release)</DefineConstants>
+    <DefineConstants>TRACE;$(Release);$(Constants)</DefineConstants>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <Optimize>true</Optimize>
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
pass the LifeCycleStage only on a linux build
this will allow it to use the appropriate /usr/share/wesay... dir (-alpha, -beta or vanilla)

it would be good to get a linux release of the release candidate by the end of the day as WeSay testing along with FW 8.3.10 is going on this week

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/wesay/21)
<!-- Reviewable:end -->
