### PR TITLE
Hide ConfigurationWindow when making mf change

### DIFF
--- a/src/WeSay.ConfigTool/ConfigurationWindow.cs
+++ b/src/WeSay.ConfigTool/ConfigurationWindow.cs
@@ -378,13 +378,19 @@ namespace WeSay.ConfigTool
 				return false;
 			}
 
-			SetupProjectControls(BuildInnerContainerForThisProject());
 			if (File.Exists(newlycreatedfromFLExPath))
 			{
+				Hide();
+				SetupProjectControls(BuildInnerContainerForThisProject());
 				_project.MakeMeaningFieldChange("definition", "gloss");
 				_project.Save();
 				SetupProjectControls(BuildInnerContainerForThisProject()); // reload to get meaning field change in gui
 				File.Delete(newlycreatedfromFLExPath);
+				Show();
+			}
+			else
+			{
+				SetupProjectControls(BuildInnerContainerForThisProject());
 			}
 			Settings.Default.MruConfigFilePaths.AddNewPath(Project.PathToConfigFile);
 			return true;


### PR DESCRIPTION
so that the screen doesn't show Definition as meaning field before automatically changing to gloss

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/wesay/26)
<!-- Reviewable:end -->
