### PR TITLE
config migration to add dataFormat

### DIFF
--- a/common/default.WeSayConfig
+++ b/common/default.WeSayConfig
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<configuration version="9">
+<configuration version="10">
   <components>
+	<dataFormat>Lift</dataFormat>
 	<viewTemplate>
 	  <fields>
 		<field>

--- a/src/WeSay.Project.Tests/ConfigMigration/WeSayConfig/WeSayConfigMigrationTests.cs
+++ b/src/WeSay.Project.Tests/ConfigMigration/WeSayConfig/WeSayConfigMigrationTests.cs
@@ -218,7 +218,23 @@ namespace WeSay.Project.Tests.ConfigMigration.WeSayConfig
 		{
 			File.WriteAllText(_pathToInputConfig,
 			@"<?xml version='1.0' encoding='utf-8'?>
-			<configuration version='6'>
+			<configuration version='8'>
+				<components>
+					<viewTemplate></viewTemplate>
+				</components>
+				<tasks><task id='Dashboard' visible='true'></task></tasks>
+			</configuration>");
+			bool didMigrate = _migrator.MigrateConfigurationXmlIfNeeded(_pathToInputConfig, _outputPath);
+			Assert.IsTrue(didMigrate);
+			AssertHasAtLeastOneMatch(_queryToCheckConfigVersion, _outputPath);
+		}
+
+		[Test]
+		public void DoesMigrateV9File()
+		{
+			File.WriteAllText(_pathToInputConfig,
+			@"<?xml version='1.0' encoding='utf-8'?>
+			<configuration version='9'>
 				<components>
 					<viewTemplate></viewTemplate>
 				</components>
@@ -505,6 +521,27 @@ namespace WeSay.Project.Tests.ConfigMigration.WeSayConfig
 			AssertHasAtLeastOneMatch("//field[fieldName='gloss' and meaningField='False']", _outputPath);
 			AssertHasAtLeastOneMatch("//field[fieldName='definition' and meaningField='True']", _outputPath);
 		}
+
+		[Test]
+		public void V10File_DataFormatAddedToComponents()
+		{
+			File.WriteAllText(
+				_pathToInputConfig,
+				@"<?xml version='1.0' encoding='utf-8'?>
+				<configuration version='8'>
+					<components>
+						<viewTemplate></viewTemplate>
+					</components>
+					<tasks>
+						<task taskName='Dashboard' visible='true'></task>
+						<task taskName='Dictionary' visible='true'></task>
+					</tasks>
+				</configuration>"
+			);
+			_migrator.MigrateConfigurationXmlIfNeeded(_pathToInputConfig, _outputPath);
+			AssertHasAtLeastOneMatch("//components/dataFormat[text()='Lift']", _outputPath);
+		}
+
 
 		[Test]
 		public void DoesNotTouchCurrentFile()

--- a/src/WeSay.Project/ConfigFile.cs
+++ b/src/WeSay.Project/ConfigFile.cs
@@ -20,7 +20,7 @@ namespace WeSay.Project
 
 	public class ConfigFile
 	{
-		public const int LatestVersion = 9;
+		public const int LatestVersion = 10;
 		private readonly XmlDocument _xmlDocument = new XmlDocument();
 
 		private string _configFilePath;

--- a/src/WeSay.Project/ConfigFileReader.cs
+++ b/src/WeSay.Project/ConfigFileReader.cs
@@ -143,6 +143,21 @@ namespace WeSay.Project
 			}
 		}
 
+		public static WeSayDataFormat GetDataFormat(string xmlConfiguration)
+		{
+			XPathDocument doc = new XPathDocument(new StringReader(xmlConfiguration));
+			XPathNavigator navigator = doc.CreateNavigator();
+			navigator = navigator.SelectSingleNode("//components//dataFormat");
+			if (navigator == null)
+			{
+				return WeSayDataFormat.Lift;
+			}
+			else
+			{
+				string format = navigator.Value;
+				return (WeSayDataFormat)System.Enum.Parse(typeof(WeSayDataFormat), format);
+			}
+		}
 
 	}
 }

--- a/src/WeSay.Project/ConfigMigration/WeSayConfig/ConfigurationMigrator.cs
+++ b/src/WeSay.Project/ConfigMigration/WeSayConfig/ConfigurationMigrator.cs
@@ -73,6 +73,12 @@ namespace WeSay.Project.ConfigMigration.WeSayConfig
 			if (configurationDoc.CreateNavigator().SelectSingleNode("configuration[@version='8']") != null)
 			{
 				MigrateUsingXSLT(configurationDoc, "MigrateConfig8To9.xsl", targetPath);
+				configurationDoc = new XPathDocument(targetPath);
+				didMigrate = true;
+			}
+			if (configurationDoc.CreateNavigator().SelectSingleNode("configuration[@version='9']") != null)
+			{
+				MigrateUsingXSLT(configurationDoc, "MigrateConfig9To10.xsl", targetPath);
 				//configurationDoc = new XPathDocument(targetPath);
 				didMigrate = true;
 			}

--- a/src/WeSay.Project/ConfigMigration/WeSayConfig/MigrateConfig9To10.xsl
+++ b/src/WeSay.Project/ConfigMigration/WeSayConfig/MigrateConfig9To10.xsl
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<!-- don't do anything to other versions -->
+	<xsl:template match="configuration[@version='9']">
+		<configuration version="10">
+			<xsl:apply-templates mode ="Migrate9To10"/>
+		</configuration>
+	</xsl:template>
+
+	<xsl:template match="@*|node()" mode="Migrate9To10">
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()"  mode="Migrate9To10"/>
+		</xsl:copy>
+	</xsl:template>
+
+	<xsl:template match="@*|node()" mode="identity">
+		<xsl:copy>
+			<xsl:apply-templates select="@*|node()"  mode="identity"/>
+		</xsl:copy>
+	</xsl:template>
+
+	<!-- ============= actual changing starts here ================ -->
+	<xsl:template match="components" mode="Migrate9To10">
+		<components>
+			<dataFormat>Lift</dataFormat>
+			<xsl:copy-of select="./*"/>
+		</components>
+	</xsl:template>
+</xsl:stylesheet>

--- a/src/WeSay.Project/WeSay.Project.csproj
+++ b/src/WeSay.Project/WeSay.Project.csproj
@@ -230,6 +230,9 @@
   <ItemGroup>
     <EmbeddedResource Include="ConfigMigration\WeSayConfig\MigrateConfig8To9.xsl" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="ConfigMigration\WeSayConfig\MigrateConfig9To10.xsl" />
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
 	   Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/WeSay.Project/WeSayWordsProject.cs
+++ b/src/WeSay.Project/WeSayWordsProject.cs
@@ -46,6 +46,8 @@ using Palaso.Data;
 
 namespace WeSay.Project
 {
+	public enum WeSayDataFormat { Lift, LCM, LiftToLCM, LCMToLift };
+
 	public class WeSayWordsProject : BasilProject, IFileLocator
 	{
 		private IList<ITask> _tasks;
@@ -89,8 +91,9 @@ namespace WeSay.Project
 			_addins = AddinSet.Create(GetAddinNodes, LocateFile);
 			_optionLists = new Dictionary<string, OptionsList>();
 //            BackupMaker = new ChorusBackupMaker();
-
 		}
+
+		public WeSayDataFormat DataFormat { get; internal set; } = WeSayDataFormat.Lift;
 
 		public IList<ITask> Tasks
 		{
@@ -468,6 +471,8 @@ namespace WeSay.Project
 			builder.Register(c => new ConfigFileReader(configFileText, defaultXmlConfigText, catalog)).SingleInstance();
 
 			builder.RegisterType<TaskCollection>().SingleInstance();
+
+			DataFormat = ConfigFileReader.GetDataFormat(configFileText);
 
 			var viewTemplates = ConfigFileReader.CreateViewTemplates(configFileText, WritingSystems);
 			foreach (var viewTemplate in viewTemplates)
@@ -1443,7 +1448,9 @@ namespace WeSay.Project
 			writer.WriteStartElement("configuration");
 			writer.WriteAttributeString("version", ConfigFile.LatestVersion.ToString());
 
+
 			writer.WriteStartElement("components");
+			writer.WriteElementString("dataFormat", DataFormat.ToString());
 			foreach (ViewTemplate template in ViewTemplates)
 			{
 				template.Write(writer);


### PR DESCRIPTION
This is expected to be used in the future for migration
from Lift to LCM

Adding it to WeSay 1.6 so that, provided no other config changes are
needed 1ater, 1.6, 2.0 and 3.0 will be compatible

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/wesay/29)
<!-- Reviewable:end -->
