### PR TITLE
final test passing

### DIFF
--- a/build/build.common.proj
+++ b/build/build.common.proj
@@ -53,7 +53,7 @@
 		<ItemGroup>
 			<TestAssemblies
 				Include="$(RootDir)/output/$(Configuration)/*.Tests.dll"
-				Exclude="$(RootDir)/output/$(Configuration)/Palaso.Tests.dll"/>
+				Exclude="$(RootDir)/output/$(Configuration)/SIL.*.Tests.dll"/>
 		</ItemGroup>
 
 		<NUnitTeamCity
@@ -66,7 +66,7 @@
 		<ItemGroup>
 			<TestAssemblies
 				Include="$(RootDir)/output/$(Configuration)/*.Tests.dll"
-				Exclude="$(RootDir)/output/$(Configuration)/Palaso.Tests.dll"/>
+				Exclude="$(RootDir)/output/$(Configuration)/SIL.*.Tests.dll"/>
 		</ItemGroup>
 
 		<NUnit


### PR DESCRIPTION
fr-US isn't known so it doesn't have suppressed latin script (this needs reviewed as it is changing the test to match what it receives)
don't run tests on SIL.*.Tests.dll

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/wesay/31)
<!-- Reviewable:end -->
