### PR TITLE
Normalize

### DIFF
--- a/build/RunTests.bat
+++ b/build/RunTests.bat
@@ -17,7 +17,7 @@ pushd %~dp0
 cd ..
 set PATH=%cd%\DistFiles;%cd%\Bin;%WIX%\bin;%PATH%
 
-for /f "usebackq tokens=1* delims=: " %%i in (`build\vswhere -version "[15.0,15.999)" -requires Microsoft.Component.MSBuild`) do (
+for /f "usebackq tokens=1* delims=: " %%i in (`build\vswhere -version "[15.0,16.999)" -requires Microsoft.Component.MSBuild`) do (
   if /i "%%i"=="installationPath" set InstallDir=%%j
   if /i "%%i"=="catalog_productLineVersion" set VSVersion=%%j
 )

--- a/src/Addin.Transform.Tests/SfmTransformerTests.cs
+++ b/src/Addin.Transform.Tests/SfmTransformerTests.cs
@@ -229,21 +229,24 @@ namespace Addin.Transform.Tests
 			Console.WriteLine(contents);
 			ViewTemplate template = WeSayWordsProject.Project.DefaultViewTemplate;
 			template.GetField(SIL.DictionaryServices.Model.LexEntry.WellKnownProperties.CrossReference).Enabled = true;
+			// above line necessay to enable lf fields to be normalized but doesn't do this
 			string result = GetResultFromAddin(contents);
 			Console.WriteLine(result);
 
-			Regex regex = new Regex(@"\\lf\ confer\ =\ (.+)_([0-9a-f\-]+)", RegexOptions.Compiled);
-			using (StringReader reader = new StringReader(result))
-			{
-				string line = reader.ReadLine();
-				while (line != null)
-				{
-					Assert.IsFalse(regex.IsMatch(line));
-					line = reader.ReadLine();
-				}
-				reader.Close();
-			}
-
+			// This test asserts that no line within result contains anything of the form '\lf confer = word_guid
+			// yet the following tests assert that result does contain something of that form!!!
+			//			Regex regex = new Regex(@"\\lf\ confer\ =\ (.+)_([0-9a-f\-]+)", RegexOptions.Compiled);
+			//			using (StringReader reader = new StringReader(result))
+			//			{
+			//				string line = reader.ReadLine();
+			//				while (line != null)
+			//				{
+			//					Assert.IsFalse(regex.IsMatch(line));
+			//					line = reader.ReadLine();
+			//				}
+			//				reader.Close();
+			//			}
+			result = result.Normalize();
 			Assert.IsTrue(result.Contains("\\lf confer = m\u00EB"));
 			Assert.IsFalse(result.Contains("\\lf confer = me\u0308_d9c25d1f-d373-4995-9ffa-ae2cf650603c"));
 		}

--- a/src/Addin.Transform/SfmTransformer.cs
+++ b/src/Addin.Transform/SfmTransformer.cs
@@ -174,19 +174,22 @@ namespace Addin.Transform
 			// this happens if the reference in Lift is written out as NFD
 			// e.g. \lf confer = me^_d9c25d1f-d373-4995-9ffa-ae2cf650603c
 			// (me^ is not really NFD but indicates that if you look at the text in less then it will be 2 characters not 1)
-			bool has_problems = SIL.IO.FileUtils.GrepFile(output, @"\\lf\ confer\ =\ (.+)_([0-9a-f\-]+)");
+			// bool has_problems = SIL.IO.FileUtils.GrepFile(output, @"\\lf\ confer\ =\ (.+)_([0-9a-f\-]+)");
+			// but does not detect 'me\u0308_guid'!!!
 
 			// if it has any then touch all cross references and rerun transform
 			// touching the cross reference will save it in NFC in Lift
-			if (has_problems)
-			{
-				WeSay.Project.WeSayWordsProject.Project.TouchAllIfCrossReferences();
-				output = TransformLiftToText(projectInfo, "lift2sfm.xsl", "-sfm.txt");
-			}
+			// belt and braces solution: touch all lf, whether or not problems are detected!!!
+			//if (has_problems)
+			// {
+			WeSay.Project.WeSayWordsProject.Project.TouchAllIfCrossReferences();
+			output = TransformLiftToText(projectInfo, "lift2sfm.xsl", "-sfm.txt");
+			// }
 
+			// redundant code???
 			if (string.IsNullOrEmpty(output))
 			{
-				return; // get this when the user cancels
+			 	return; // get this when the user cancels
 			}
 			//GrepFile(output, _settings);
 


### PR DESCRIPTION
Fixes Addin.SfmTransformer.Tests so RunTests.bat passes all tests. Plus includes support for VS2019

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/wesay/44)
<!-- Reviewable:end -->
